### PR TITLE
Remove all pre-pivot content — full InvoiceOps brand alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,10 @@ Path aliases: `@/` → `src/`, `@/domains/*` → `src/domains/*`, `@/types/*` �
 **Workflow for every feature, fix, or chore:**
 1. Branch off `dev`: `git checkout dev && git pull && git checkout -b feat/my-feature`
 2. Open PR → `dev` when ready
-3. Once merged into `dev`, promote: `dev → staging → main` (each as a separate PR)
-4. Delete the feature branch after it is merged — never leave stale branches
+3. **Wait for Copilot to post its review** (`gh pr view <N> --repo AndreLiar/splitfact --json reviews`). Fix genuine issues it raises; note dismissed false positives. If Copilot approves, merge normally — no bypass needed.
+4. Once merged into `dev`, promote: `dev → staging → main` (each as a separate PR, each awaiting Copilot review)
+5. Delete the feature branch after it is merged — never leave stale branches
+6. Admin bypass (disable protection → merge → restore) is a last resort for emergencies only — always flag it explicitly
 
 Schema changes: run `nvm use 20 && npx prisma db push` after editing `prisma/schema.prisma`.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Splitfact
+# InvoiceOps
 
 **The AI back office for French e-invoicing compliance.**
 
@@ -7,9 +7,9 @@
 [![Prisma](https://img.shields.io/badge/Prisma-ORM-2D3748?logo=prisma)](https://prisma.io/)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
-Splitfact automates the path from approved work to compliant issued invoice — for French agencies and service SMEs navigating the 2026–2027 e-invoicing reform.
+InvoiceOps automates the path from approved work to compliant issued invoice — for French agencies and service SMEs navigating the 2026–2027 e-invoicing reform.
 
-Most invoicing tools stop at document creation. Splitfact completes the workflow: it collects the data, validates compliance, routes the invoice, tracks status, and surfaces only exceptions for human review.
+Most invoicing tools stop at document creation. InvoiceOps completes the workflow: it collects the data, validates compliance, routes the invoice, tracks status, and surfaces only exceptions for human review.
 
 ---
 
@@ -247,4 +247,4 @@ MIT — see [LICENSE](LICENSE).
 
 ---
 
-*Splitfact — Issue compliant invoices and handle exceptions automatically.*
+*InvoiceOps — Issue compliant invoices and handle exceptions automatically.*

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -135,8 +135,8 @@ function SignInContent() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           {[
             { icon: 'bi-receipt', label: 'Facturation e-invoicing conforme' },
-            { icon: 'bi-robot', label: 'IA fiscale URSSAF intégrée' },
-            { icon: 'bi-people', label: 'Collectifs & partage de revenus' },
+            { icon: 'bi-shield-check', label: 'Moteur de conformité EN 16931' },
+            { icon: 'bi-inbox', label: 'Inbox des exceptions centralisée' },
           ].map(f => (
             <div key={f.label} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
               <div style={{

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -178,7 +178,7 @@ export default function Sidebar() {
               lineHeight: 1.2,
               fontFeatureSettings: '"cv01", "ss03"',
             }}>
-              Splitfact
+              InvoiceOps
             </div>
             <div style={{
               fontSize: "0.5625rem",

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 
 interface Notification {
   id: string;
-  type: 'URSSAF_REMINDER' | 'TVA_THRESHOLD_WARNING' | 'TVA_THRESHOLD_EXCEEDED' | 'GENERAL';
+  type: 'INVOICE_BLOCKED' | 'COMPLIANCE_ALERT' | 'PAYMENT_REMINDER' | 'GENERAL';
   title: string;
   message: string;
   isRead: boolean;
@@ -114,36 +114,36 @@ export default function NotificationsPage() {
   // Get notification icon and color
   const getNotificationIcon = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'bi-calendar-check';
-      case 'TVA_THRESHOLD_WARNING': return 'bi-exclamation-triangle';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'bi-exclamation-octagon';
+      case 'INVOICE_BLOCKED': return 'bi-exclamation-octagon';
+      case 'COMPLIANCE_ALERT': return 'bi-shield-exclamation';
+      case 'PAYMENT_REMINDER': return 'bi-credit-card';
       default: return 'bi-info-circle';
     }
   };
 
   const getNotificationColor = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'text-primary';
-      case 'TVA_THRESHOLD_WARNING': return 'text-warning';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'text-danger';
+      case 'INVOICE_BLOCKED': return 'text-danger';
+      case 'COMPLIANCE_ALERT': return 'text-warning';
+      case 'PAYMENT_REMINDER': return 'text-primary';
       default: return 'text-info';
     }
   };
 
   const getBadgeColor = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'bg-primary';
-      case 'TVA_THRESHOLD_WARNING': return 'bg-warning';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'bg-danger';
+      case 'INVOICE_BLOCKED': return 'bg-danger';
+      case 'COMPLIANCE_ALERT': return 'bg-warning';
+      case 'PAYMENT_REMINDER': return 'bg-primary';
       default: return 'bg-info';
     }
   };
 
   const getTypeLabel = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'URSSAF';
-      case 'TVA_THRESHOLD_WARNING': return 'TVA';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'TVA URGENT';
+      case 'INVOICE_BLOCKED': return 'Bloquée';
+      case 'COMPLIANCE_ALERT': return 'Conformité';
+      case 'PAYMENT_REMINDER': return 'Paiement';
       case 'GENERAL': return 'Général';
       default: return 'Info';
     }
@@ -238,7 +238,7 @@ export default function NotificationsPage() {
               <p className="text-muted">
                 {filter === 'unread' 
                   ? 'Toutes vos notifications ont été lues' 
-                  : 'Vous recevrez ici les rappels URSSAF et alertes TVA'}
+                  : 'Vous recevrez ici les alertes de conformité et de facturation'}
               </p>
             </div>
           ) : (

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -143,7 +143,6 @@ function SettingsPageInner() {
       setProfile((p) => ({ ...p, [key]: e.target.value })),
   });
 
-  const isMicro = ['MicroBIC', 'BNC'].includes(profile.fiscalRegime);
   const isCompany = ['SASU', 'EURL', 'SARL', 'SAS'].includes(profile.legalStatus);
 
   if (status === 'loading' || profileLoading) {
@@ -224,8 +223,6 @@ function SettingsPageInner() {
                     <label className="form-label fw-medium">Régime fiscal <span className="text-danger">*</span></label>
                     <select className={`form-select ${profileErrors.fiscalRegime ? 'is-invalid' : ''}`} {...field('fiscalRegime')}>
                       <option value="">-- Choisir --</option>
-                      <option value="MicroBIC">Micro-BIC (commerçant)</option>
-                      <option value="BNC">BNC (libéral)</option>
                       <option value="EI">EI (entreprise individuelle)</option>
                       <option value="SASU">SASU / SAS</option>
                       <option value="Other">Autre</option>
@@ -243,32 +240,6 @@ function SettingsPageInner() {
                     {profileErrors.legalStatus && <div className="invalid-feedback">{profileErrors.legalStatus}</div>}
                   </div>
 
-                  {/* Micro-entrepreneur type — conditional */}
-                  {isMicro && (
-                    <div className="col-md-6">
-                      <label className="form-label fw-medium">Type micro-entrepreneur <span className="text-danger">*</span></label>
-                      <select className={`form-select ${profileErrors.microEntrepreneurType ? 'is-invalid' : ''}`} {...field('microEntrepreneurType')}>
-                        <option value="">-- Choisir --</option>
-                        <option value="COMMERCANT">Commerçant</option>
-                        <option value="PRESTATAIRE">Prestataire de services</option>
-                        <option value="LIBERAL">Libéral</option>
-                      </select>
-                      {profileErrors.microEntrepreneurType && <div className="invalid-feedback">{profileErrors.microEntrepreneurType}</div>}
-                    </div>
-                  )}
-
-                  {/* Declaration frequency — conditional */}
-                  {isMicro && (
-                    <div className="col-md-6">
-                      <label className="form-label fw-medium">Fréquence de déclaration URSSAF <span className="text-danger">*</span></label>
-                      <select className={`form-select ${profileErrors.declarationFrequency ? 'is-invalid' : ''}`} {...field('declarationFrequency')}>
-                        <option value="">-- Choisir --</option>
-                        <option value="monthly">Mensuelle</option>
-                        <option value="quarterly">Trimestrielle</option>
-                      </select>
-                      {profileErrors.declarationFrequency && <div className="invalid-feedback">{profileErrors.declarationFrequency}</div>}
-                    </div>
-                  )}
 
                   {/* TVA number — optional */}
                   <div className="col-md-6">

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -26,7 +26,7 @@ export default function OfflinePage() {
                   </h1>
                   
                   <p className="text-muted mb-4 lh-base">
-                    Vous êtes actuellement hors ligne. Certaines fonctionnalités de Splitfact 
+                    Vous êtes actuellement hors ligne. Certaines fonctionnalités d'InvoiceOps
                     ne sont pas disponibles, mais vous pouvez encore :
                   </p>
                 </div>
@@ -54,10 +54,10 @@ export default function OfflinePage() {
                   
                   <div className="col-md-6">
                     <div className="d-flex align-items-center p-3 bg-light rounded-3">
-                      <i className="bi bi-calculator text-info me-3 fs-5"></i>
+                      <i className="bi bi-shield-check text-info me-3 fs-5"></i>
                       <div className="text-start">
-                        <div className="fw-semibold small">Calculateur</div>
-                        <div className="text-muted small">URSSAF & TVA</div>
+                        <div className="fw-semibold small">Conformité</div>
+                        <div className="text-muted small">Score e-invoicing</div>
                       </div>
                     </div>
                   </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ const painPoints = [
 ];
 
 const steps = [
-  { n: "01", title: "Déclencheur capturé", text: "Devis signé, jalon validé, récurrence mensuelle ou timesheet approuvé — Splitfact reçoit le signal.", icon: "bi-lightning-charge" },
+  { n: "01", title: "Déclencheur capturé", text: "Devis signé, jalon validé, récurrence mensuelle ou timesheet approuvé — InvoiceOps reçoit le signal.", icon: "bi-lightning-charge" },
   { n: "02", title: "Agent collecte les données", text: "L'IA enrichit la facture : SIRET, TVA, mentions légales, adresse. Elle détecte les champs manquants.", icon: "bi-robot" },
   { n: "03", title: "Exceptions remontées", text: "Seuls les cas ambigus apparaissent dans l'inbox. Le reste s'écoule automatiquement vers l'émission.", icon: "bi-funnel" },
   { n: "04", title: "Émission avec confiance", text: "Facture conforme, traçable, prête pour la plateforme de dématérialisation partenaire 2026.", icon: "bi-send-check" },
@@ -219,7 +219,7 @@ export default function LandingPage() {
                 marginBottom: "2rem",
                 maxWidth: "480px",
               }}>
-                Splitfact automatise le chemin entre devis signé, données client incomplètes et facture prête à émettre. Votre équipe ne traite plus que les exceptions.
+                InvoiceOps automatise le chemin entre devis signé, données client incomplètes et facture prête à émettre. Votre équipe ne traite plus que les exceptions.
               </p>
 
               {/* CTAs */}
@@ -697,7 +697,7 @@ export default function LandingPage() {
                 2026-2027 arrive. Préparez votre workflow maintenant.
               </h2>
               <p style={{ fontSize: "1rem", color: "#8a8f98", lineHeight: 1.7 }}>
-                La réforme impose le passage à la facturation électronique pour toutes les entreprises françaises assujetties à la TVA. Splitfact génère des factures Factur-X (PDF/A-3 + XML) prêtes pour les plateformes partenaires.
+                La réforme impose le passage à la facturation électronique pour toutes les entreprises françaises assujetties à la TVA. InvoiceOps génère des factures Factur-X (PDF/A-3 + XML) prêtes pour les plateformes partenaires.
               </p>
             </FadeUp>
 
@@ -752,7 +752,7 @@ export default function LandingPage() {
               }}>
                 <i className="bi bi-shield-check" style={{ color: "#D4921A", fontSize: "1.125rem", flexShrink: 0 }} />
                 <div style={{ fontSize: "0.8125rem", color: "#8a8f98" }}>
-                  Splitfact génère des factures <strong style={{ color: "#d0d6e0" }}>Factur-X conformes</strong> — PDF/A-3 avec XML embarqué, compatible PDP.
+                  InvoiceOps génère des factures <strong style={{ color: "#d0d6e0" }}>Factur-X conformes</strong> — PDF/A-3 avec XML embarqué, compatible PDP.
                 </div>
               </div>
             </div>
@@ -1086,7 +1086,7 @@ export default function LandingPage() {
                 }}>
                   <i className="bi bi-lightning-fill" style={{ color: "#08090a", fontSize: "0.75rem" }} />
                 </div>
-                <span style={{ fontSize: "0.9375rem", fontWeight: 590, color: "#f7f8f8" }}>Splitfact</span>
+                <span style={{ fontSize: "0.9375rem", fontWeight: 590, color: "#f7f8f8" }}>InvoiceOps</span>
               </div>
               <p style={{ fontSize: "0.8125rem", color: "#62666d", lineHeight: 1.7, maxWidth: "240px", marginBottom: "1.25rem" }}>
                 Back-office de facturation IA pour les agences et sociétés de services françaises.
@@ -1172,7 +1172,7 @@ export default function LandingPage() {
             gap: "0.75rem",
           }}>
             <div style={{ fontSize: "0.75rem", color: "#62666d" }}>
-              © {new Date().getFullYear()} Splitfact. Tous droits réservés.
+              © {new Date().getFullYear()} InvoiceOps. Tous droits réservés.
             </div>
             <div style={{ display: "flex", gap: "1.5rem" }}>
               {[

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Politique de Confidentialite - InvoiceOps',
-  description: 'Politique de confidentialite et protection des donnees personnelles de InvoiceOps',
+  title: 'Politique de Confidentialité - InvoiceOps',
+  description: 'Politique de confidentialité et protection des données personnelles de InvoiceOps',
 };
 
 export default function PrivacyPolicyPage() {
@@ -25,9 +25,9 @@ export default function PrivacyPolicyPage() {
               <div className="mb-5">
                 <h2 className="h4 mb-3">1. Introduction</h2>
                 <p>
-                  InvoiceOps s&apos;engage a proteger votre vie privee et vos donnees personnelles. Cette politique de confidentialite 
-                  explique comment nous collectons, utilisons, stockons et protegeons vos informations lorsque vous utilisez 
-                  notre plateforme de gestion fiscale pour micro-entrepreneurs.
+                  InvoiceOps s&apos;engage à protéger votre vie privée et vos données personnelles. Cette politique de confidentialité
+                  explique comment nous collectons, utilisons, stockons et protégeons vos informations lorsque vous utilisez
+                  notre plateforme de workflow de facturation pour agences et sociétés de services françaises.
                 </p>
               </div>
 

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Conditions Generales d\'Utilisation - InvoiceOps',
-  description: 'Conditions generales d\'utilisation de la plateforme InvoiceOps pour micro-entrepreneurs',
+  title: 'Conditions Générales d\'Utilisation - InvoiceOps',
+  description: 'Conditions générales d\'utilisation de la plateforme InvoiceOps pour agences et sociétés de services françaises.',
 };
 
 export default function TermsOfServicePage() {
@@ -15,130 +15,130 @@ export default function TermsOfServicePage() {
             <div className="card-body p-5">
               <h1 className="h2 mb-4 text-primary">
                 <i className="bi bi-file-text me-2"></i>
-                Conditions Generales d&apos;Utilisation
+                Conditions Générales d&apos;Utilisation
               </h1>
-              
+
               <p className="text-muted mb-4">
-                <strong>Derniere mise a jour :</strong> {new Date().toLocaleDateString('fr-FR')}
+                <strong>Dernière mise à jour :</strong> {new Date().toLocaleDateString('fr-FR')}
               </p>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">1. Objet et Acceptation</h2>
                 <p>
-                  Les presentes Conditions Generales d&apos;Utilisation (CGU) regissent l&apos;utilisation de la plateforme 
-                  InvoiceOps, service de gestion fiscale et comptable destine aux micro-entrepreneurs francais.
+                  Les présentes Conditions Générales d&apos;Utilisation (CGU) régissent l&apos;utilisation de la plateforme
+                  InvoiceOps, service de workflow de facturation électronique destiné aux agences et sociétés de services françaises.
                 </p>
                 <p>
-                  L&apos;utilisation de la plateforme implique l&apos;acceptation pleine et entiere des presentes CGU. 
+                  L&apos;utilisation de la plateforme implique l&apos;acceptation pleine et entière des présentes CGU.
                   Si vous n&apos;acceptez pas ces conditions, vous ne devez pas utiliser nos services.
                 </p>
               </div>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">2. Description des Services</h2>
-                
+
                 <h3 className="h5 mb-2">2.1 Services Principaux</h3>
                 <ul className="mb-3">
-                  <li>Gestion des factures et devis</li>
-                  <li>Suivi du chiffre d&apos;affaires et des seuils</li>
-                  <li>Generation de rapports URSSAF et TVA</li>
-                  <li>Assistant fiscal intelligent avec IA</li>
-                  <li>Gestion des clients et projets</li>
-                  <li>Tableaux de bord et analyses</li>
+                  <li>Automatisation du workflow de facturation (du déclencheur à l&apos;émission)</li>
+                  <li>Moteur de conformité — vérification des champs EN 16931 obligatoires</li>
+                  <li>Inbox des exceptions — centralisation des factures bloquées</li>
+                  <li>Génération de factures Factur-X (PDF/A-3 + XML) conformes à la réforme 2026-2027</li>
+                  <li>Suivi des statuts de livraison et de paiement</li>
+                  <li>Tableau de bord et piste d&apos;audit complète</li>
                 </ul>
 
-                <h3 className="h5 mb-2">2.2 Fonctionnalites Avancees</h3>
+                <h3 className="h5 mb-2">2.2 Fonctionnalités Avancées</h3>
                 <ul className="mb-3">
-                  <li>Recherche web intelligente pour conseils fiscaux</li>
-                  <li>Alertes automatiques et notifications</li>
-                  <li>Rapports multi-sources et benchmarking</li>
-                  <li>Multi-agents IA pour analyses complexes</li>
+                  <li>Extraction automatique de données depuis PDF et documents</li>
+                  <li>Validation SIRET via INSEE SIRENE v3</li>
+                  <li>Soumission PPF / Chorus Pro via PISTE API</li>
+                  <li>Notifications intelligentes avec retry automatique</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">3. Integrations et Services Tiers</h2>
-                
+                <h2 className="h4 mb-3">3. Intégrations et Services Tiers</h2>
+
                 <div className="alert alert-warning">
                   <i className="bi bi-exclamation-triangle me-2"></i>
                   <strong>Important :</strong> Les services tiers ont leurs propres conditions d&apos;utilisation.
-                  Nous ne sommes pas responsables de leur disponibilite ou de leurs modifications.
+                  Nous ne sommes pas responsables de leur disponibilité ou de leurs modifications.
                 </div>
               </div>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">4. Obligations de l&apos;Utilisateur</h2>
-                
+
                 <h3 className="h5 mb-2">4.1 Usage Conforme</h3>
-                <p>Vous vous engagez a :</p>
+                <p>Vous vous engagez à :</p>
                 <ul className="mb-3">
-                  <li>Utiliser la plateforme dans le respect de la legislation</li>
+                  <li>Utiliser la plateforme dans le respect de la législation</li>
                   <li>Ne pas porter atteinte aux droits de tiers</li>
-                  <li>Maintenir la confidentialite de vos identifiants</li>
-                  <li>Signaler toute utilisation non autorisee de votre compte</li>
+                  <li>Maintenir la confidentialité de vos identifiants</li>
+                  <li>Signaler toute utilisation non autorisée de votre compte</li>
                 </ul>
 
-                <h3 className="h5 mb-2">4.2 Donnees Fiscales</h3>
-                <p>Concernant vos donnees fiscales, vous devez :</p>
+                <h3 className="h5 mb-2">4.2 Données de Facturation</h3>
+                <p>Concernant vos données de facturation, vous devez :</p>
                 <ul>
-                  <li>Fournir des informations exactes et completes</li>
-                  <li>Verifier la coherence des donnees synchronisees</li>
-                  <li>Conserver vos justificatifs selon la reglementation</li>
-                  <li>Assumer la responsabilite finale de vos declarations</li>
+                  <li>Fournir des informations exactes et complètes</li>
+                  <li>Vérifier la cohérence des données avant émission</li>
+                  <li>Conserver vos justificatifs selon la réglementation</li>
+                  <li>Assumer la responsabilité finale de vos factures émises</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">5. Assistant IA et Conseils Automatises</h2>
-                
-                <h3 className="h5 mb-2">5.1 Nature des Conseils</h3>
+                <h2 className="h4 mb-3">5. IA et Extraction Automatique</h2>
+
+                <h3 className="h5 mb-2">5.1 Nature du Service</h3>
                 <p>
-                  L&apos;assistant IA fournit des conseils bases sur vos donnees et les reglementations en vigueur. 
-                  Ces conseils sont informatifs et ne constituent pas un avis juridique ou comptable personnalise.
+                  InvoiceOps utilise l&apos;IA pour extraire et structurer des données de facturation.
+                  Ces extractions sont indicatives — vous devez vérifier et valider les données avant émission.
                 </p>
 
-                <h3 className="h5 mb-2">5.2 Responsabilite</h3>
+                <h3 className="h5 mb-2">5.2 Responsabilité</h3>
                 <ul className="mb-3">
-                  <li>Vous devez verifier et valider tous les conseils recus</li>
-                  <li>Consulter un professionnel pour les situations complexes</li>
-                  <li>L&apos;IA peut commettre des erreurs ou être incomplete</li>
+                  <li>Vous devez vérifier et valider toutes les données extraites</li>
+                  <li>L&apos;IA peut commettre des erreurs ou être incomplète</li>
+                  <li>La conformité finale de chaque facture relève de votre responsabilité</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">6. Protection des Donnees</h2>
+                <h2 className="h4 mb-3">6. Protection des Données</h2>
                 <p>
-                  Le traitement de vos donnees personnelles est regi par notre{' '}
-                  <a href="/privacy-policy" className="text-decoration-none">Politique de Confidentialite</a>, 
-                  qui fait partie integrante des presentes CGU.
+                  Le traitement de vos données personnelles est régi par notre{' '}
+                  <a href="/privacy-policy" className="text-decoration-none">Politique de Confidentialité</a>,
+                  qui fait partie intégrante des présentes CGU.
                 </p>
-                
-                <h3 className="h5 mb-2">6.1 Securite</h3>
+
+                <h3 className="h5 mb-2">6.1 Sécurité</h3>
                 <ul className="mb-3">
                   <li>Chiffrement de toutes les communications</li>
-                  <li>Authentification securisee</li>
-                  <li>Sauvegardes regulieres et chiffrees</li>
-                  <li>Acces restreint aux donnees sensibles</li>
+                  <li>Authentification sécurisée</li>
+                  <li>Sauvegardes régulières et chiffrées</li>
+                  <li>Accès restreint aux données sensibles</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">7. Limitation de Responsabilite</h2>
+                <h2 className="h4 mb-3">7. Limitation de Responsabilité</h2>
                 <div className="alert alert-info">
-                  <p><strong>Important :</strong> InvoiceOps est un outil d&apos;aide a la gestion fiscale. 
+                  <p><strong>Important :</strong> InvoiceOps est un outil d&apos;automatisation du workflow de facturation.
                   Vous restez seul responsable de :</p>
                   <ul className="mb-0">
-                    <li>L&apos;exactitude de vos declarations fiscales</li>
-                    <li>Le respect des obligations legales</li>
-                    <li>La validation des conseils automatises</li>
-                    <li>La sauvegarde de vos donnees importantes</li>
+                    <li>L&apos;exactitude de vos factures émises</li>
+                    <li>Le respect des obligations légales de facturation</li>
+                    <li>La validation des données extraites automatiquement</li>
+                    <li>La sauvegarde de vos données importantes</li>
                   </ul>
                 </div>
               </div>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">8. Contact et Support</h2>
-                
+
                 <div className="row">
                   <div className="col-md-6">
                     <h3 className="h6">Support Technique</h3>
@@ -163,9 +163,8 @@ export default function TermsOfServicePage() {
                   Engagement InvoiceOps
                 </h4>
                 <p className="mb-0">
-                  Nous nous engageons a fournir un service de qualite, respectueux de vos donnees 
-                  et conforme a la reglementation francaise et europeenne. Notre equipe reste 
-                  disponible pour repondre a vos questions et ameliorer continuellement la plateforme.
+                  Nous nous engageons à fournir un service de qualité, respectueux de vos données
+                  et conforme à la réglementation française et européenne sur la facturation électronique.
                 </p>
               </div>
 
@@ -175,11 +174,11 @@ export default function TermsOfServicePage() {
                 </p>
                 <Link href="/" className="btn btn-primary me-3">
                   <i className="bi bi-house me-2"></i>
-                  Retour a l&apos;accueil
+                  Retour à l&apos;accueil
                 </Link>
                 <Link href="/privacy-policy" className="btn btn-outline-secondary me-3">
                   <i className="bi bi-shield-check me-2"></i>
-                  Politique de Confidentialite
+                  Politique de Confidentialité
                 </Link>
                 <Link href="/dashboard" className="btn btn-outline-primary">
                   <i className="bi bi-speedometer2 me-2"></i>


### PR DESCRIPTION
## Summary

- **Sidebar**: "Splitfact" → "InvoiceOps"
- **Sign-in page**: replaced "IA fiscale URSSAF intégrée" and "Collectifs & partage de revenus" with pivot-aligned features (moteur de conformité EN 16931, inbox des exceptions centralisée)
- **Offline page**: brand fix + URSSAF calculator card replaced with conformité e-invoicing
- **Notifications page**: removed `URSSAF_REMINDER` / `TVA_THRESHOLD_WARNING` / `TVA_THRESHOLD_EXCEEDED` types; replaced with `INVOICE_BLOCKED` / `COMPLIANCE_ALERT` / `PAYMENT_REMINDER`; updated all icons, colors, badges, labels, and empty-state copy
- **Settings page**: removed MicroBIC/BNC fiscal regime options and the `isMicro` conditional blocks for URSSAF declaration frequency and micro-entrepreneur type
- **Landing page, README, privacy policy, terms of service**: InvoiceOps brand and pivot-aligned copy throughout

## Test plan

- [ ] Sign-in page shows correct pivot features in the left panel
- [ ] Sidebar shows "InvoiceOps" in the logo area
- [ ] Offline page shows "InvoiceOps" and conformité card
- [ ] Notifications page renders without TypeScript errors; empty state shows new copy
- [ ] Settings page fiscal regime select no longer contains MicroBIC/BNC; no URSSAF frequency field shown