### PR TITLE
Promote dev → staging: InvoiceOps pivot cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,10 @@ Path aliases: `@/` → `src/`, `@/domains/*` → `src/domains/*`, `@/types/*` �
 **Workflow for every feature, fix, or chore:**
 1. Branch off `dev`: `git checkout dev && git pull && git checkout -b feat/my-feature`
 2. Open PR → `dev` when ready
-3. Once merged into `dev`, promote: `dev → staging → main` (each as a separate PR)
-4. Delete the feature branch after it is merged — never leave stale branches
+3. **Wait for Copilot to post its review** (`gh pr view <N> --repo AndreLiar/splitfact --json reviews`). Fix genuine issues it raises; note dismissed false positives. If Copilot approves, merge normally — no bypass needed.
+4. Once merged into `dev`, promote: `dev → staging → main` (each as a separate PR, each awaiting Copilot review)
+5. Delete the feature branch after it is merged — never leave stale branches
+6. Admin bypass (disable protection → merge → restore) is a last resort for emergencies only — always flag it explicitly
 
 Schema changes: run `nvm use 20 && npx prisma db push` after editing `prisma/schema.prisma`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,12 @@ Path aliases: `@/` → `src/`, `@/domains/*` → `src/domains/*`, `@/types/*` �
 - `staging` → pre-production
 - `dev` → active development
 
+**Workflow for every feature, fix, or chore:**
+1. Branch off `dev`: `git checkout dev && git pull && git checkout -b feat/my-feature`
+2. Open PR → `dev` when ready
+3. Once merged into `dev`, promote: `dev → staging → main` (each as a separate PR)
+4. Delete the feature branch after it is merged — never leave stale branches
+
 Schema changes: run `nvm use 20 && npx prisma db push` after editing `prisma/schema.prisma`.
 
 ## Node Version Gotchas

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ These businesses invoice frequently, manage billing across email, CRM, proposals
 ### 1. Clone and install
 ```bash
 git clone https://github.com/AndreLiar/splitfact.git
-cd splitfact/splitfact-app
+cd splitfact
 nvm use 22 && npm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,424 +1,250 @@
-# 📊 Splitfact
+# Splitfact
 
-**AI-Powered Invoicing & Fiscal Management Platform for French Micro-Entrepreneurs**
+**The AI back office for French e-invoicing compliance.**
 
-[![Next.js](https://img.shields.io/badge/Next.js-15.3.5-black?logo=next.js)](https://nextjs.org/)
+[![Next.js](https://img.shields.io/badge/Next.js-15.5.14-black?logo=next.js)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue?logo=typescript)](https://www.typescriptlang.org/)
-[![OpenAI](https://img.shields.io/badge/OpenAI-GPT--4o--mini-green?logo=openai)](https://openai.com/)
 [![Prisma](https://img.shields.io/badge/Prisma-ORM-2D3748?logo=prisma)](https://prisma.io/)
-[![Tests](https://img.shields.io/badge/Tests-100%25-brightgreen?logo=jest)](https://jestjs.io/)
+[![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
-**Splitfact** is a comprehensive, AI-powered invoicing and fiscal management platform specifically designed for French micro-entrepreneurs (auto-entrepreneurs) and freelance collectives. The application combines professional invoicing capabilities with intelligent business insights, automated tax compliance, and collaborative revenue sharing.
+Splitfact automates the path from approved work to compliant issued invoice — for French agencies and service SMEs navigating the 2026–2027 e-invoicing reform.
 
----
-
-## 🚀 Features
-
-### 💰 **Invoicing & Payments**
-- **Professional Invoice Generation** with French legal compliance
-- **Stripe Integration** for secure online payments
-- **Multi-currency Support** with automatic conversion
-- **Recurring Invoice Automation**
-- **Payment Tracking & Reminders**
-
-### 🤖 **AI-Powered Insights**  
-- **Intelligent Query Routing** (Simple → Direct AI, Complex → Multi-Agent)
-- **French Fiscal Advisory** with real-time compliance checks
-- **URSSAF Declaration Assistance** and deadline reminders  
-- **TVA Threshold Monitoring** with automated warnings
-- **Cash Flow Predictions** and business analytics
-- **Cost-Optimized AI** (€0.30-€0.90/month for 20 users)
-
-### 👥 **Collective Management**
-- **Revenue Sharing** with customizable distribution rules
-- **Team Collaboration** with role-based permissions
-- **Client Assignment** and workload balancing
-- **Collective Reporting** and analytics
-
-### 📋 **Compliance & Reporting**
-- **French Tax Compliance** (MicroBIC, BNC regimes)
-- **Automated URSSAF Reports** with calculation assistance
-- **TVA Management** and threshold tracking
-- **Export to CSV/PDF** for accountants
-- **Deadline Notifications** and fiscal calendar
-
-### 🔔 **Smart Notifications**
-- **URSSAF Reminders** (2 days before deadlines)
-- **TVA Threshold Alerts** when approaching limits
-- **Payment Due Notifications**
-- **Cash Flow Insights** and recommendations
+Most invoicing tools stop at document creation. Splitfact completes the workflow: it collects the data, validates compliance, routes the invoice, tracks status, and surfaces only exceptions for human review.
 
 ---
 
-## 🛠️ Tech Stack
+## Why Now
 
-### **Frontend**
-- **Next.js 15.3.5** (App Router, React Server Components)
-- **TypeScript** for type safety
-- **Tailwind CSS** for responsive design
-- **Shadcn/UI** components
+French e-invoicing reform creates a hard deadline:
+- **1 September 2026** — all VAT-liable businesses must be able to *receive* e-invoices
+- **1 September 2027** — SMEs and micro-businesses must also *issue* them
 
-### **Backend**
-- **Next.js API Routes** (serverless functions)
-- **NextAuth.js** for authentication
-- **Prisma ORM** with PostgreSQL
-- **Stripe API** for payments
-
-### **AI & Intelligence**
-- **OpenAI GPT-4o-mini** for production (cost-optimized)
-- **Ollama** for local development
-- **Multi-Agent System** for complex fiscal analysis
-- **LangChain** for AI orchestration
-- **Smart Query Routing** to optimize costs
-
-### **Infrastructure**
-- **Vercel** deployment ready
-- **Neon PostgreSQL** database
-- **Cloudinary** for file storage
-- **Resend** for email notifications
+The winning product is not compliance software. It is software that **gets the admin work done**.
 
 ---
 
-## 📋 Prerequisites
+## Who It's For
 
-- **Node.js** 18+ 
-- **npm** or **yarn**
-- **PostgreSQL** database (or Neon)
-- **OpenAI API Key** (for production)
-- **Stripe Account** (for payments)
+French agencies and service SMEs with 5–50 employees:
+- creative agencies, consulting firms, dev shops
+- staffing and recruiting firms
+- expert-service boutiques
+
+These businesses invoice frequently, manage billing across email, CRM, proposals, and PDFs, and feel the regulatory pressure without having strong internal finance ops.
 
 ---
 
-## 🚀 Quick Start
+## Core Value
 
-### 1. **Clone the Repository**
+**From deal won to compliant paid invoice, with humans only handling exceptions.**
+
+---
+
+## What the Product Does
+
+### Invoice Readiness Engine
+- Validates every EN 16931 mandatory field before issuance
+- Distinguishes blocking compliance errors from optional warnings
+- Readiness state (`ready` / `blocked`) is visible on every invoice
+
+### Billing Workflow State Machine
+- Tracks invoices through explicit states: `triggered → collecting_data → blocked → ready_for_review → ready_to_issue → issued`
+- Timestamped transitions with full audit trail
+- Invalid transitions are prevented
+
+### AI-Powered OCR & Data Extraction
+- Upload a PDF or image → structured invoice data extracted automatically
+- **Groq** (primary): vision `llama-4-scout-17b`, text `mistral-saba-24b`
+- **Ollama Cloud** (fallback): vision `gemma3:27b`, text `ministral-3:8b`
+- Automatic failover on rate limits, 5xx, and timeouts
+
+### E-Invoicing Output (Factur-X / PPF)
+- **Factur-X CII XML** generation compliant with EN 16931
+- **UBL 2.1** serializer
+- **PPF / Chorus Pro** submission via PISTE API with automatic daily retry
+- Webhook endpoint for PPF delivery status updates
+
+### E-Reporting (B2C — art. 290 CGI)
+- Aggregates B2C invoices by TVA rate into CII TypeCode 751 XML
+- Auto-submits on the 2nd of each month
+
+### Compliance Monitoring
+- Compliance score 0–100 with penalty simulation (art. 1737 II CGI — €15/invoice, capped €45k/year)
+- URSSAF reminders (monthly/quarterly) with TVA threshold alerts
+- SIRET validation via INSEE SIRENE v3
+
+### Payments
+- Stripe Connect — clients pay online, funds go directly to the service provider's account
+
+### Notifications
+- In-app queue with exponential backoff retry (1min → 5min → 15min → 1h → 2h)
+- Duplicate prevention within the same day
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 15.5.14 (App Router) |
+| Language | TypeScript |
+| UI | Bootstrap 5 + Bootstrap Icons |
+| Database | Prisma ORM + Neon PostgreSQL |
+| Auth | NextAuth.js |
+| Payments | Stripe Connect |
+| AI / OCR | Groq (primary) → Ollama Cloud (fallback) |
+| Email | Resend |
+| File Storage | Cloudinary |
+| Deployment | Vercel |
+
+---
+
+## Quick Start
+
+### Prerequisites
+- Node.js 22 (required for `libxmljs`)
+- Node.js 20 for Prisma CLI only
+- PostgreSQL (Neon recommended)
+
+### 1. Clone and install
 ```bash
 git clone https://github.com/AndreLiar/splitfact.git
-cd splitfact
+cd splitfact/splitfact-app
+nvm use 22 && npm install
 ```
 
-### 2. **Install Dependencies**
-```bash
-npm install
-```
-
-### 3. **Environment Setup**
-Create `.env` file with the following variables:
-
+### 2. Environment setup
+Create `.env.local`:
 ```env
 # Database
-DATABASE_URL="postgresql://user:password@localhost:5432/splitfact"
+DATABASE_URL="postgresql://user:password@host/splitfact"
 
-# Authentication
+# Auth
 NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=your-secret-key
+NEXTAUTH_SECRET=your-secret
 
-# AI Configuration
-AI_MODE=local  # Use 'openai' for production
-OPENAI_API_KEY=sk-proj-your-openai-key
-OPENAI_MODEL=gpt-4o-mini
-
-# Ollama (for local development)
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=deepseek-coder-v2:latest
+# LLM Router
+LLM_PRIMARY=groq
+LLM_FALLBACK=ollama
+GROQ_API_KEY=gsk_...
+GROQ_MODEL=mistral-saba-24b
+GROQ_VISION_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
+OLLAMA_API_KEY=your-ollama-cloud-key
+OLLAMA_BASE_URL=https://ollama.com/v1
+OLLAMA_MODEL=ministral-3:8b
+OLLAMA_VISION_MODEL=gemma3:27b
 
 # Stripe
-STRIPE_SECRET_KEY=sk_test_your-stripe-key
-STRIPE_WEBHOOK_SECRET=whsec_your-webhook-secret
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
 
 # Email
-RESEND_API_KEY=re_your-resend-key
-EMAIL_FROM=your-email@domain.com
+RESEND_API_KEY=re_...
+EMAIL_FROM=no-reply@yourdomain.com
 
 # File Storage
-CLOUDINARY_CLOUD_NAME=your-cloud-name
-CLOUDINARY_API_KEY=your-api-key
-CLOUDINARY_API_SECRET=your-api-secret
+CLOUDINARY_CLOUD_NAME=...
+CLOUDINARY_API_KEY=...
+CLOUDINARY_API_SECRET=...
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=...
 
-# French e-invoicing — PISTE / PPF (Chorus Pro)
-PISTE_CLIENT_ID=your-piste-client-id
-PISTE_CLIENT_SECRET=your-piste-client-secret
-PISTE_ENV=sandbox                          # "sandbox" | "production"
-PISTE_WEBHOOK_SECRET=your-webhook-secret   # shared secret for /api/webhooks/ppf
+# Cron
+CRON_SECRET=your-cron-secret
 
-# INSEE SIRENE — SIRET validation
-SIRENE_API_KEY=your-sirene-api-key
+# E-Invoicing — PISTE / Chorus Pro
+PISTE_CLIENT_ID=...
+PISTE_CLIENT_SECRET=...
+PISTE_ENV=sandbox
+CPRO_TECH_LOGIN=...
+CPRO_TECH_PASSWORD=...
+PISTE_WEBHOOK_SECRET=...
+
+# SIRET validation
+SIRENE_API_KEY=...
 ```
 
-### 4. **Database Setup**
+### 3. Database
 ```bash
-# Generate Prisma client
-npx prisma generate
-
-# Run migrations
-npx prisma db push
-
-# (Optional) Seed database
-npx prisma db seed
+nvm use 20 && npx prisma db push && nvm use 22
 ```
 
-### 5. **Start Development Server**
+### 4. Run
 ```bash
-npm run dev
+npm run dev   # http://localhost:3000
 ```
-
-Visit [http://localhost:3000](http://localhost:3000) to see the application.
 
 ---
 
-## 🧪 Testing
+## Commands
 
-### **Run All Tests**
 ```bash
-npm test                    # Jest unit tests
-npm run test:e2e           # Playwright e2e tests  
-npm run test:full          # Complete test suite (100% success rate)
-```
+npm run dev              # Dev server
+npm run build            # Production build
+npm run lint             # ESLint
 
-### **Quality Checks**
-```bash
-npm run lint               # ESLint code quality
-npm run type-check         # TypeScript validation
-npm run build              # Production build test
-```
+npm test                 # Unit tests
+npm run test:api         # API integration tests
+npm run test:coverage    # Coverage report
+npm run test:e2e         # Playwright
 
-### **Test Coverage**
-- ✅ **Unit Tests**: 72/72 passing
-- ✅ **API Integration Tests**: All endpoints covered
-- ✅ **TypeScript**: Zero compilation errors
-- ✅ **ESLint**: Zero linting errors
-- ✅ **Build**: Production ready
-
----
-
-## 🔧 Development Workflow
-
-### **Branch Strategy**
-```
-main     ← Production (auto-deploy to Vercel)
-├── staging ← Pre-production testing  
-└── dev     ← Active development
-```
-
-### **Local Development**
-```bash
-# Switch to development branch
-git checkout dev
-
-# Start with Ollama (local AI)
-AI_MODE=local npm run dev
-
-# Run tests continuously  
-npm run test:watch
-```
-
-### **AI Development Modes**
-
-#### **Local Development** (Free)
-```env
-AI_MODE=local
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=deepseek-coder-v2:latest
-```
-
-#### **Production** (Cost-Optimized)
-```env
-AI_MODE=openai
-OPENAI_MODEL=gpt-4o-mini
-OPENAI_API_KEY=sk-proj-your-key
+npm run db:health        # DB connectivity check
+npm run db:backup        # Dump DB
+npm run pwa:validate     # Validate PWA setup
 ```
 
 ---
 
-## 💰 AI Cost Management
+## Project Structure
 
-### **Optimized for €5 Budget**
-- **Model**: GPT-4o-mini (cheapest OpenAI model)
-- **Smart Routing**: Simple queries bypass expensive multi-agent processing
-- **Token Limits**: 1000 max tokens per request
-- **Budget Protection**: Automatic blocking when approaching limits
-- **Usage Tracking**: Real-time cost monitoring
-
-### **Expected Costs (20 users/month)**
 ```
-Simple Queries (80%): €0.001 each = €0.16
-Complex Queries (20%): €0.005 each = €0.20
-─────────────────────────────────────────
-Total Monthly Cost: ~€0.36 (7% of budget) ✅
-```
-
-### **Monitor Usage**
-```bash
-# Check current usage
-curl http://localhost:3000/api/ai/usage
-
-# Reset monthly stats
-curl -X POST http://localhost:3000/api/ai/usage \
-  -H "Content-Type: application/json" \
-  -d '{"action": "reset"}'
+src/
+├── domains/
+│   ├── invoices/        # invoice-readiness, ubl-serializer, facturx/, activity-log
+│   ├── compliance/      # compliance scoring, e-reporting/
+│   ├── notifications/   # NotificationService with retry queue
+│   └── fiscal/          # fiscal-context (user business metrics)
+├── lib/                 # Infrastructure: prisma, auth, email, cloudinary, piste-api, sirene-api
+│   └── llm-router.ts    # Groq → Ollama Cloud failover
+├── app/
+│   ├── api/             # API routes
+│   │   ├── invoices/    # CRUD, PDF, PPF submission
+│   │   ├── cron/        # PPF retry, e-reporting, URSSAF reminders
+│   │   ├── stripe/      # Onboarding, webhooks
+│   │   └── compliance/  # Compliance score
+│   └── dashboard/       # App pages
+└── types/
+    ├── fiscal.ts         # UserFiscalProfile
+    └── api.ts            # ApiResponse<T>, PaginatedResponse<T>
 ```
 
 ---
 
-## 🚀 Deployment
-
-### **Vercel Deployment** (Recommended)
-
-#### **1. Connect Repository**
-```bash
-# Deploy to Vercel  
-vercel --prod
-
-# Set environment variables in Vercel dashboard
-# Switch AI_MODE to 'openai' for production
-```
-
-#### **2. Database Setup**
-```bash
-# Use Neon PostgreSQL for production
-# Update DATABASE_URL in Vercel environment variables
-```
-
-#### **3. Domain Configuration**
-```bash
-# Update NEXTAUTH_URL to your production domain
-# Configure Stripe webhooks for production domain
-```
-
-### **Manual Deployment**
-```bash
-# Build for production
-npm run build
-
-# Start production server  
-npm run start
-```
-
----
-
-## 📁 Project Structure
+## Branch Workflow
 
 ```
-splitfact/
-├── src/
-│   ├── app/                    # Next.js App Router
-│   │   ├── api/               # API routes
-│   │   │   ├── ai/           # AI services
-│   │   │   ├── auth/         # Authentication  
-│   │   │   ├── invoices/     # Invoice management
-│   │   │   └── reports/      # Fiscal reports
-│   │   ├── dashboard/        # Main application
-│   │   └── components/       # React components
-│   ├── lib/                   # Utilities & services
-│   │   ├── ai-service.ts     # Universal AI service
-│   │   ├── openai-service.ts # OpenAI integration
-│   │   ├── cost-monitor.ts   # Usage tracking
-│   │   ├── fiscal-agents.ts  # Multi-agent system
-│   │   └── prisma.ts         # Database client
-│   └── types/                # TypeScript definitions
-├── prisma/                   # Database schema & migrations
-├── tests/                    # Test suites
-├── docs/                     # Documentation
-└── scripts/                  # Automation scripts
+main      ← Production (auto-deploy to Vercel)
+staging   ← Pre-production
+dev       ← Active development
 ```
 
----
-
-## 🔒 Security Features
-
-- **NextAuth.js** authentication with session management
-- **CSRF Protection** on all forms
-- **Rate Limiting** on API endpoints
-- **Input Validation** with Zod schemas
-- **SQL Injection Prevention** with Prisma ORM
-- **Secure Headers** configured
-- **Environment Variable Protection**
+1. Branch from `dev`: `git checkout -b feat/my-feature`
+2. PR → `dev`, wait for Copilot review, merge
+3. Promote: `dev → staging → main` (separate PRs)
+4. Delete feature branch after merge
 
 ---
 
-## 🌍 French Business Compliance
+## Node Version Notes
 
-### **Supported Fiscal Regimes**
-- ✅ **Micro-BIC** (Commercial activities)
-- ✅ **BNC** (Liberal professions)  
-- ✅ **Auto-entrepreneur** status
-- ✅ **TVA** management and thresholds
-
-### **URSSAF Integration**
-- **Monthly/Quarterly** declaration assistance
-- **Automatic calculations** for social contributions
-- **Deadline reminders** and notifications
-- **Export formats** compatible with URSSAF
-
-### **TVA Thresholds (2024)**
-- **Commercial**: €91,900
-- **Services**: €36,800
-- **Liberal professions**: €36,800
-- **Automatic monitoring** and alerts
+- **Dev / Jest / builds**: Node 22 (`nvm use 22`)
+- **Prisma CLI only**: Node 20 (`nvm use 20`)
 
 ---
 
-## 🤝 Contributing
+## License
 
-### **Development Setup**
-```bash
-# Fork and clone the repository
-git clone https://github.com/YOUR-USERNAME/splitfact.git
-
-# Create feature branch from dev
-git checkout dev
-git checkout -b feature/your-feature-name
-
-# Make changes and test
-npm run test:full
-
-# Submit pull request to dev branch
-```
-
-### **Code Standards**
-- **TypeScript** required for all new code
-- **ESLint** configuration must pass
-- **100% test coverage** for new features
-- **Conventional commits** for commit messages
+MIT — see [LICENSE](LICENSE).
 
 ---
 
-## 📄 License
-
-This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
-
----
-
-## 💬 Support
-
-- **Documentation**: [docs/](docs/)
-- **Issues**: [GitHub Issues](https://github.com/AndreLiar/splitfact/issues)
-- **Email**: kanmegneandre@gmail.com
-
----
-
-## 🎯 Roadmap
-
-### **Phase 1** (Current)
-- ✅ Core invoicing functionality
-- ✅ AI-powered fiscal advice  
-- ✅ URSSAF compliance tools
-- ✅ Cost-optimized AI integration
-
-### **Phase 2** (Q2 2025)
-- 🔄 Advanced analytics dashboard
-- 🔄 Mobile application (React Native)
-- 🔄 Multi-language support
-- 🔄 Advanced collective features
-
-### **Phase 3** (Q3 2025)
-- 🔄 API for third-party integrations
-- 🔄 Marketplace for fiscal templates
-- 🔄 Advanced AI predictions
-- 🔄 European expansion
-
----
-
-**Made with ❤️ for French micro-entrepreneurs**
-
-*Empowering freelancers and small businesses with intelligent fiscal management.*
+*Splitfact — Issue compliant invoices and handle exceptions automatically.*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Splitfact
+# InvoiceOps
 
 **The AI back office for French e-invoicing compliance.**
 
@@ -7,9 +7,9 @@
 [![Prisma](https://img.shields.io/badge/Prisma-ORM-2D3748?logo=prisma)](https://prisma.io/)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
-Splitfact automates the path from approved work to compliant issued invoice — for French agencies and service SMEs navigating the 2026–2027 e-invoicing reform.
+InvoiceOps automates the path from approved work to compliant issued invoice — for French agencies and service SMEs navigating the 2026–2027 e-invoicing reform.
 
-Most invoicing tools stop at document creation. Splitfact completes the workflow: it collects the data, validates compliance, routes the invoice, tracks status, and surfaces only exceptions for human review.
+Most invoicing tools stop at document creation. InvoiceOps completes the workflow: it collects the data, validates compliance, routes the invoice, tracks status, and surfaces only exceptions for human review.
 
 ---
 
@@ -247,4 +247,4 @@ MIT — see [LICENSE](LICENSE).
 
 ---
 
-*Splitfact — Issue compliant invoices and handle exceptions automatically.*
+*InvoiceOps — Issue compliant invoices and handle exceptions automatically.*

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -135,8 +135,8 @@ function SignInContent() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           {[
             { icon: 'bi-receipt', label: 'Facturation e-invoicing conforme' },
-            { icon: 'bi-robot', label: 'IA fiscale URSSAF intégrée' },
-            { icon: 'bi-people', label: 'Collectifs & partage de revenus' },
+            { icon: 'bi-shield-check', label: 'Moteur de conformité EN 16931' },
+            { icon: 'bi-inbox', label: 'Inbox des exceptions centralisée' },
           ].map(f => (
             <div key={f.label} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
               <div style={{

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -178,7 +178,7 @@ export default function Sidebar() {
               lineHeight: 1.2,
               fontFeatureSettings: '"cv01", "ss03"',
             }}>
-              Splitfact
+              InvoiceOps
             </div>
             <div style={{
               fontSize: "0.5625rem",

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -112,7 +112,7 @@ export default function NotificationsPage() {
   };
 
   // Get notification icon and color
-  const getNotificationIcon = (type: string) => {
+  const getNotificationIcon = (type: Notification['type']) => {
     switch (type) {
       case 'INVOICE_BLOCKED': return 'bi-exclamation-octagon';
       case 'COMPLIANCE_ALERT': return 'bi-shield-exclamation';
@@ -121,7 +121,7 @@ export default function NotificationsPage() {
     }
   };
 
-  const getNotificationColor = (type: string) => {
+  const getNotificationColor = (type: Notification['type']) => {
     switch (type) {
       case 'INVOICE_BLOCKED': return 'text-danger';
       case 'COMPLIANCE_ALERT': return 'text-warning';
@@ -130,7 +130,7 @@ export default function NotificationsPage() {
     }
   };
 
-  const getBadgeColor = (type: string) => {
+  const getBadgeColor = (type: Notification['type']) => {
     switch (type) {
       case 'INVOICE_BLOCKED': return 'bg-danger';
       case 'COMPLIANCE_ALERT': return 'bg-warning';
@@ -139,7 +139,7 @@ export default function NotificationsPage() {
     }
   };
 
-  const getTypeLabel = (type: string) => {
+  const getTypeLabel = (type: Notification['type']) => {
     switch (type) {
       case 'INVOICE_BLOCKED': return 'Bloquée';
       case 'COMPLIANCE_ALERT': return 'Conformité';

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 
 interface Notification {
   id: string;
-  type: 'URSSAF_REMINDER' | 'TVA_THRESHOLD_WARNING' | 'TVA_THRESHOLD_EXCEEDED' | 'GENERAL';
+  type: 'INVOICE_BLOCKED' | 'COMPLIANCE_ALERT' | 'PAYMENT_REMINDER' | 'GENERAL';
   title: string;
   message: string;
   isRead: boolean;
@@ -114,36 +114,36 @@ export default function NotificationsPage() {
   // Get notification icon and color
   const getNotificationIcon = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'bi-calendar-check';
-      case 'TVA_THRESHOLD_WARNING': return 'bi-exclamation-triangle';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'bi-exclamation-octagon';
+      case 'INVOICE_BLOCKED': return 'bi-exclamation-octagon';
+      case 'COMPLIANCE_ALERT': return 'bi-shield-exclamation';
+      case 'PAYMENT_REMINDER': return 'bi-credit-card';
       default: return 'bi-info-circle';
     }
   };
 
   const getNotificationColor = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'text-primary';
-      case 'TVA_THRESHOLD_WARNING': return 'text-warning';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'text-danger';
+      case 'INVOICE_BLOCKED': return 'text-danger';
+      case 'COMPLIANCE_ALERT': return 'text-warning';
+      case 'PAYMENT_REMINDER': return 'text-primary';
       default: return 'text-info';
     }
   };
 
   const getBadgeColor = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'bg-primary';
-      case 'TVA_THRESHOLD_WARNING': return 'bg-warning';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'bg-danger';
+      case 'INVOICE_BLOCKED': return 'bg-danger';
+      case 'COMPLIANCE_ALERT': return 'bg-warning';
+      case 'PAYMENT_REMINDER': return 'bg-primary';
       default: return 'bg-info';
     }
   };
 
   const getTypeLabel = (type: string) => {
     switch (type) {
-      case 'URSSAF_REMINDER': return 'URSSAF';
-      case 'TVA_THRESHOLD_WARNING': return 'TVA';
-      case 'TVA_THRESHOLD_EXCEEDED': return 'TVA URGENT';
+      case 'INVOICE_BLOCKED': return 'Bloquée';
+      case 'COMPLIANCE_ALERT': return 'Conformité';
+      case 'PAYMENT_REMINDER': return 'Paiement';
       case 'GENERAL': return 'Général';
       default: return 'Info';
     }
@@ -238,7 +238,7 @@ export default function NotificationsPage() {
               <p className="text-muted">
                 {filter === 'unread' 
                   ? 'Toutes vos notifications ont été lues' 
-                  : 'Vous recevrez ici les rappels URSSAF et alertes TVA'}
+                  : 'Vous recevrez ici les alertes de conformité et de facturation'}
               </p>
             </div>
           ) : (

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -143,7 +143,6 @@ function SettingsPageInner() {
       setProfile((p) => ({ ...p, [key]: e.target.value })),
   });
 
-  const isMicro = ['MicroBIC', 'BNC'].includes(profile.fiscalRegime);
   const isCompany = ['SASU', 'EURL', 'SARL', 'SAS'].includes(profile.legalStatus);
 
   if (status === 'loading' || profileLoading) {
@@ -224,8 +223,6 @@ function SettingsPageInner() {
                     <label className="form-label fw-medium">Régime fiscal <span className="text-danger">*</span></label>
                     <select className={`form-select ${profileErrors.fiscalRegime ? 'is-invalid' : ''}`} {...field('fiscalRegime')}>
                       <option value="">-- Choisir --</option>
-                      <option value="MicroBIC">Micro-BIC (commerçant)</option>
-                      <option value="BNC">BNC (libéral)</option>
                       <option value="EI">EI (entreprise individuelle)</option>
                       <option value="SASU">SASU / SAS</option>
                       <option value="Other">Autre</option>
@@ -243,32 +240,6 @@ function SettingsPageInner() {
                     {profileErrors.legalStatus && <div className="invalid-feedback">{profileErrors.legalStatus}</div>}
                   </div>
 
-                  {/* Micro-entrepreneur type — conditional */}
-                  {isMicro && (
-                    <div className="col-md-6">
-                      <label className="form-label fw-medium">Type micro-entrepreneur <span className="text-danger">*</span></label>
-                      <select className={`form-select ${profileErrors.microEntrepreneurType ? 'is-invalid' : ''}`} {...field('microEntrepreneurType')}>
-                        <option value="">-- Choisir --</option>
-                        <option value="COMMERCANT">Commerçant</option>
-                        <option value="PRESTATAIRE">Prestataire de services</option>
-                        <option value="LIBERAL">Libéral</option>
-                      </select>
-                      {profileErrors.microEntrepreneurType && <div className="invalid-feedback">{profileErrors.microEntrepreneurType}</div>}
-                    </div>
-                  )}
-
-                  {/* Declaration frequency — conditional */}
-                  {isMicro && (
-                    <div className="col-md-6">
-                      <label className="form-label fw-medium">Fréquence de déclaration URSSAF <span className="text-danger">*</span></label>
-                      <select className={`form-select ${profileErrors.declarationFrequency ? 'is-invalid' : ''}`} {...field('declarationFrequency')}>
-                        <option value="">-- Choisir --</option>
-                        <option value="monthly">Mensuelle</option>
-                        <option value="quarterly">Trimestrielle</option>
-                      </select>
-                      {profileErrors.declarationFrequency && <div className="invalid-feedback">{profileErrors.declarationFrequency}</div>}
-                    </div>
-                  )}
 
                   {/* TVA number — optional */}
                   <div className="col-md-6">

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -26,7 +26,7 @@ export default function OfflinePage() {
                   </h1>
                   
                   <p className="text-muted mb-4 lh-base">
-                    Vous êtes actuellement hors ligne. Certaines fonctionnalités de Splitfact 
+                    Vous êtes actuellement hors ligne. Certaines fonctionnalités d'InvoiceOps
                     ne sont pas disponibles, mais vous pouvez encore :
                   </p>
                 </div>
@@ -54,10 +54,10 @@ export default function OfflinePage() {
                   
                   <div className="col-md-6">
                     <div className="d-flex align-items-center p-3 bg-light rounded-3">
-                      <i className="bi bi-calculator text-info me-3 fs-5"></i>
+                      <i className="bi bi-shield-check text-info me-3 fs-5"></i>
                       <div className="text-start">
-                        <div className="fw-semibold small">Calculateur</div>
-                        <div className="text-muted small">URSSAF & TVA</div>
+                        <div className="fw-semibold small">Conformité</div>
+                        <div className="text-muted small">Score e-invoicing</div>
                       </div>
                     </div>
                   </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1201,10 +1201,14 @@ export default function LandingPage() {
           0%   { background-position: 0% center; }
           100% { background-position: 200% center; }
         }
-        .icp-pill:hover,
+        .icp-pill:hover {
+          border-color: rgba(212, 146, 26, 0.3) !important;
+        }
         .icp-pill:focus-visible {
           border-color: rgba(212, 146, 26, 0.3) !important;
-          outline: none;
+          outline: 2px solid rgba(212, 146, 26, 0.85);
+          outline-offset: 2px;
+          box-shadow: 0 0 0 4px rgba(212, 146, 26, 0.2);
         }
         @media (max-width: 991px) {
           .hero-grid, .two-col-grid { grid-template-columns: 1fr !important; gap: 2.5rem !important; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ const painPoints = [
 ];
 
 const steps = [
-  { n: "01", title: "Déclencheur capturé", text: "Devis signé, jalon validé, récurrence mensuelle ou timesheet approuvé — Splitfact reçoit le signal.", icon: "bi-lightning-charge" },
+  { n: "01", title: "Déclencheur capturé", text: "Devis signé, jalon validé, récurrence mensuelle ou timesheet approuvé — InvoiceOps reçoit le signal.", icon: "bi-lightning-charge" },
   { n: "02", title: "Agent collecte les données", text: "L'IA enrichit la facture : SIRET, TVA, mentions légales, adresse. Elle détecte les champs manquants.", icon: "bi-robot" },
   { n: "03", title: "Exceptions remontées", text: "Seuls les cas ambigus apparaissent dans l'inbox. Le reste s'écoule automatiquement vers l'émission.", icon: "bi-funnel" },
   { n: "04", title: "Émission avec confiance", text: "Facture conforme, traçable, prête pour la plateforme de dématérialisation partenaire 2026.", icon: "bi-send-check" },
@@ -219,7 +219,7 @@ export default function LandingPage() {
                 marginBottom: "2rem",
                 maxWidth: "480px",
               }}>
-                Splitfact automatise le chemin entre devis signé, données client incomplètes et facture prête à émettre. Votre équipe ne traite plus que les exceptions.
+                InvoiceOps automatise le chemin entre devis signé, données client incomplètes et facture prête à émettre. Votre équipe ne traite plus que les exceptions.
               </p>
 
               {/* CTAs */}
@@ -697,7 +697,7 @@ export default function LandingPage() {
                 2026-2027 arrive. Préparez votre workflow maintenant.
               </h2>
               <p style={{ fontSize: "1rem", color: "#8a8f98", lineHeight: 1.7 }}>
-                La réforme impose le passage à la facturation électronique pour toutes les entreprises françaises assujetties à la TVA. Splitfact génère des factures Factur-X (PDF/A-3 + XML) prêtes pour les plateformes partenaires.
+                La réforme impose le passage à la facturation électronique pour toutes les entreprises françaises assujetties à la TVA. InvoiceOps génère des factures Factur-X (PDF/A-3 + XML) prêtes pour les plateformes partenaires.
               </p>
             </FadeUp>
 
@@ -752,7 +752,7 @@ export default function LandingPage() {
               }}>
                 <i className="bi bi-shield-check" style={{ color: "#D4921A", fontSize: "1.125rem", flexShrink: 0 }} />
                 <div style={{ fontSize: "0.8125rem", color: "#8a8f98" }}>
-                  Splitfact génère des factures <strong style={{ color: "#d0d6e0" }}>Factur-X conformes</strong> — PDF/A-3 avec XML embarqué, compatible PDP.
+                  InvoiceOps génère des factures <strong style={{ color: "#d0d6e0" }}>Factur-X conformes</strong> — PDF/A-3 avec XML embarqué, compatible PDP.
                 </div>
               </div>
             </div>
@@ -1086,7 +1086,7 @@ export default function LandingPage() {
                 }}>
                   <i className="bi bi-lightning-fill" style={{ color: "#08090a", fontSize: "0.75rem" }} />
                 </div>
-                <span style={{ fontSize: "0.9375rem", fontWeight: 590, color: "#f7f8f8" }}>Splitfact</span>
+                <span style={{ fontSize: "0.9375rem", fontWeight: 590, color: "#f7f8f8" }}>InvoiceOps</span>
               </div>
               <p style={{ fontSize: "0.8125rem", color: "#62666d", lineHeight: 1.7, maxWidth: "240px", marginBottom: "1.25rem" }}>
                 Back-office de facturation IA pour les agences et sociétés de services françaises.
@@ -1172,7 +1172,7 @@ export default function LandingPage() {
             gap: "0.75rem",
           }}>
             <div style={{ fontSize: "0.75rem", color: "#62666d" }}>
-              © {new Date().getFullYear()} Splitfact. Tous droits réservés.
+              © {new Date().getFullYear()} InvoiceOps. Tous droits réservés.
             </div>
             <div style={{ display: "flex", gap: "1.5rem" }}>
               {[

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,11 +19,20 @@ const steps = [
   { n: "04", title: "Émission avec confiance", text: "Facture conforme, traçable, prête pour la plateforme de dématérialisation partenaire 2026.", icon: "bi-send-check" },
 ];
 
+const icpTypes = [
+  { icon: "bi-palette", label: "Agences créatives" },
+  { icon: "bi-briefcase", label: "Cabinets de conseil" },
+  { icon: "bi-code-square", label: "Dev shops" },
+  { icon: "bi-people", label: "Sociétés de staffing" },
+  { icon: "bi-lightbulb", label: "Boutiques d'expertise" },
+];
+
 const features = [
-  { icon: "bi-cpu", label: "Agent IA fiscal", text: "Comprend le régime URSSAF, les seuils TVA, BNC, MicroBIC — répond en français." },
+  { icon: "bi-clipboard2-check", label: "Moteur de conformité", text: "Chaque facture reçoit un état clair : prête ou bloquée. Les champs manquants sont listés avant l'émission." },
+  { icon: "bi-funnel", label: "Inbox des exceptions", text: "Les factures bloquées apparaissent dans une file centralisée. Votre équipe n'intervient que sur les cas ambigus." },
   { icon: "bi-file-earmark-check", label: "Factur-X natif", text: "Génère des factures PDF/A-3 avec données XML embarquées — format EU e-invoicing 2026." },
   { icon: "bi-credit-card", label: "Stripe Connect", text: "Lien de paiement en un clic sur chaque facture. Encaissement directement sur votre compte." },
-  { icon: "bi-bell-fill", label: "Relances automatiques", text: "Notifications intelligentes pour les factures en retard, les échéances à J-7, J-3, J+1." },
+  { icon: "bi-bell-fill", label: "Relances automatiques", text: "Notifications intelligentes pour les factures en retard, les échéances fiscales et les statuts de livraison." },
   { icon: "bi-graph-up-arrow", label: "Tableau de bord", text: "Volume facturé, encaissements, exceptions, délais — vue temps réel sur votre trésorerie." },
 ];
 
@@ -437,6 +446,51 @@ export default function LandingPage() {
       </div>
 
       {/* ══════════════════════════════════════════════════════
+          ICP — FOR WHOM
+      ══════════════════════════════════════════════════════ */}
+      <section style={{ padding: "4rem 0" }} aria-labelledby="pour-qui-title" data-testid="pour-qui-section">
+        <div className="main-container">
+          <FadeUp>
+            <div style={{ textAlign: "center", marginBottom: "2.5rem" }}>
+              <SectionLabel>Pour qui</SectionLabel>
+              <h2 id="pour-qui-title" data-testid="pour-qui-heading" style={{
+                fontSize: "clamp(1.5rem, 2.5vw, 2rem)",
+                fontWeight: 590,
+                letterSpacing: "-0.03em",
+                color: "#f7f8f8",
+                marginBottom: "0.75rem",
+              }}>
+                Agences et sociétés de services françaises, 5–50 personnes.
+              </h2>
+              <p data-testid="pour-qui-description" style={{ fontSize: "0.9375rem", color: "#8a8f98", maxWidth: "520px", margin: "0 auto" }}>
+                Celles qui facturent souvent, gèrent des données client éparpillées, et n'ont pas de DAF interne pour absorber la réforme 2026-2027.
+              </p>
+            </div>
+
+            <div data-testid="pour-qui-tags" style={{ display: "flex", justifyContent: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+              {icpTypes.map(t => (
+                <span key={t.label} className="icp-pill" style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "7px",
+                  padding: "8px 16px",
+                  backgroundColor: "rgba(255,255,255,0.02)",
+                  border: "1px solid rgba(255,255,255,0.07)",
+                  borderRadius: "9999px",
+                  fontSize: "0.8125rem",
+                  color: "#d0d6e0",
+                  transition: "border-color 150ms ease",
+                }}>
+                  <i className={`bi ${t.icon}`} style={{ color: "#D4921A", fontSize: "0.875rem" }} />
+                  {t.label}
+                </span>
+              ))}
+            </div>
+          </FadeUp>
+        </div>
+      </section>
+
+      {/* ══════════════════════════════════════════════════════
           PROBLEM
       ══════════════════════════════════════════════════════ */}
       <section id="problem" style={{ padding: "6rem 0" }}>
@@ -455,9 +509,19 @@ export default function LandingPage() {
                 }}>
                   Votre équipe ne manque pas d'un outil de plus. Elle manque d'un système.
                 </h2>
-                <p style={{ fontSize: "1rem", color: "#8a8f98", lineHeight: 1.7, maxWidth: "420px" }}>
+                <p style={{ fontSize: "1rem", color: "#8a8f98", lineHeight: 1.7, maxWidth: "420px", marginBottom: "1.5rem" }}>
                   Chaque agence a déjà un CRM, un logiciel de facturation et une boîte mail. Le problème, c'est que rien ne relie ces sources au moment d'émettre.
                 </p>
+                <div style={{
+                  padding: "1.25rem 1.5rem",
+                  borderLeft: "2px solid #D4921A",
+                  backgroundColor: "rgba(212,146,26,0.04)",
+                  borderRadius: "0 8px 8px 0",
+                }}>
+                  <p style={{ fontSize: "0.9375rem", color: "#d0d6e0", lineHeight: 1.65, fontStyle: "italic", margin: 0 }}>
+                    "La vraie douleur n'est pas de créer la facture. C'est de finir le processus sans aller-retour."
+                  </p>
+                </div>
               </div>
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.75rem" }}>
                 {painPoints.map((p, i) => (
@@ -568,10 +632,10 @@ export default function LandingPage() {
               color: "#f7f8f8",
               marginBottom: "0.75rem",
             }}>
-              Tout ce dont une agence française a besoin pour facturer sans friction.
+              Un workflow complet, pas un outil de plus.
             </h2>
-            <p style={{ fontSize: "1rem", color: "#8a8f98", marginBottom: "3rem", maxWidth: "500px" }}>
-              Pas un énième logiciel de compta. Un back-office de billing conçu pour vos contraintes réelles.
+            <p style={{ fontSize: "1rem", color: "#8a8f98", marginBottom: "3rem", maxWidth: "520px" }}>
+              Du déclencheur à la facture émise : conformité, exceptions centralisées, et suivi opérationnel — tout dans un seul système.
             </p>
           </FadeUp>
 
@@ -1136,6 +1200,11 @@ export default function LandingPage() {
         @keyframes shimmer {
           0%   { background-position: 0% center; }
           100% { background-position: 200% center; }
+        }
+        .icp-pill:hover,
+        .icp-pill:focus-visible {
+          border-color: rgba(212, 146, 26, 0.3) !important;
+          outline: none;
         }
         @media (max-width: 991px) {
           .hero-grid, .two-col-grid { grid-template-columns: 1fr !important; gap: 2.5rem !important; }

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Politique de Confidentialite - InvoiceOps',
-  description: 'Politique de confidentialite et protection des donnees personnelles de InvoiceOps',
+  title: 'Politique de Confidentialité - InvoiceOps',
+  description: 'Politique de confidentialité et protection des données personnelles de InvoiceOps',
 };
 
 export default function PrivacyPolicyPage() {
@@ -25,9 +25,9 @@ export default function PrivacyPolicyPage() {
               <div className="mb-5">
                 <h2 className="h4 mb-3">1. Introduction</h2>
                 <p>
-                  InvoiceOps s&apos;engage a proteger votre vie privee et vos donnees personnelles. Cette politique de confidentialite 
-                  explique comment nous collectons, utilisons, stockons et protegeons vos informations lorsque vous utilisez 
-                  notre plateforme de gestion fiscale pour micro-entrepreneurs.
+                  InvoiceOps s&apos;engage à protéger votre vie privée et vos données personnelles. Cette politique de confidentialité
+                  explique comment nous collectons, utilisons, stockons et protégeons vos informations lorsque vous utilisez
+                  notre plateforme de workflow de facturation pour agences et sociétés de services françaises.
                 </p>
               </div>
 

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Conditions Generales d\'Utilisation - InvoiceOps',
-  description: 'Conditions generales d\'utilisation de la plateforme InvoiceOps pour micro-entrepreneurs',
+  title: 'Conditions Générales d\'Utilisation - InvoiceOps',
+  description: 'Conditions générales d\'utilisation de la plateforme InvoiceOps pour agences et sociétés de services françaises.',
 };
 
 export default function TermsOfServicePage() {
@@ -15,130 +15,130 @@ export default function TermsOfServicePage() {
             <div className="card-body p-5">
               <h1 className="h2 mb-4 text-primary">
                 <i className="bi bi-file-text me-2"></i>
-                Conditions Generales d&apos;Utilisation
+                Conditions Générales d&apos;Utilisation
               </h1>
-              
+
               <p className="text-muted mb-4">
-                <strong>Derniere mise a jour :</strong> {new Date().toLocaleDateString('fr-FR')}
+                <strong>Dernière mise à jour :</strong> {new Date().toLocaleDateString('fr-FR')}
               </p>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">1. Objet et Acceptation</h2>
                 <p>
-                  Les presentes Conditions Generales d&apos;Utilisation (CGU) regissent l&apos;utilisation de la plateforme 
-                  InvoiceOps, service de gestion fiscale et comptable destine aux micro-entrepreneurs francais.
+                  Les présentes Conditions Générales d&apos;Utilisation (CGU) régissent l&apos;utilisation de la plateforme
+                  InvoiceOps, service de workflow de facturation électronique destiné aux agences et sociétés de services françaises.
                 </p>
                 <p>
-                  L&apos;utilisation de la plateforme implique l&apos;acceptation pleine et entiere des presentes CGU. 
+                  L&apos;utilisation de la plateforme implique l&apos;acceptation pleine et entière des présentes CGU.
                   Si vous n&apos;acceptez pas ces conditions, vous ne devez pas utiliser nos services.
                 </p>
               </div>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">2. Description des Services</h2>
-                
+
                 <h3 className="h5 mb-2">2.1 Services Principaux</h3>
                 <ul className="mb-3">
-                  <li>Gestion des factures et devis</li>
-                  <li>Suivi du chiffre d&apos;affaires et des seuils</li>
-                  <li>Generation de rapports URSSAF et TVA</li>
-                  <li>Assistant fiscal intelligent avec IA</li>
-                  <li>Gestion des clients et projets</li>
-                  <li>Tableaux de bord et analyses</li>
+                  <li>Automatisation du workflow de facturation (du déclencheur à l&apos;émission)</li>
+                  <li>Moteur de conformité — vérification des champs EN 16931 obligatoires</li>
+                  <li>Inbox des exceptions — centralisation des factures bloquées</li>
+                  <li>Génération de factures Factur-X (PDF/A-3 + XML) conformes à la réforme 2026-2027</li>
+                  <li>Suivi des statuts de livraison et de paiement</li>
+                  <li>Tableau de bord et piste d&apos;audit complète</li>
                 </ul>
 
-                <h3 className="h5 mb-2">2.2 Fonctionnalites Avancees</h3>
+                <h3 className="h5 mb-2">2.2 Fonctionnalités Avancées</h3>
                 <ul className="mb-3">
-                  <li>Recherche web intelligente pour conseils fiscaux</li>
-                  <li>Alertes automatiques et notifications</li>
-                  <li>Rapports multi-sources et benchmarking</li>
-                  <li>Multi-agents IA pour analyses complexes</li>
+                  <li>Extraction automatique de données depuis PDF et documents</li>
+                  <li>Validation SIRET via INSEE SIRENE v3</li>
+                  <li>Soumission PPF / Chorus Pro via PISTE API</li>
+                  <li>Notifications intelligentes avec retry automatique</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">3. Integrations et Services Tiers</h2>
-                
+                <h2 className="h4 mb-3">3. Intégrations et Services Tiers</h2>
+
                 <div className="alert alert-warning">
                   <i className="bi bi-exclamation-triangle me-2"></i>
                   <strong>Important :</strong> Les services tiers ont leurs propres conditions d&apos;utilisation.
-                  Nous ne sommes pas responsables de leur disponibilite ou de leurs modifications.
+                  Nous ne sommes pas responsables de leur disponibilité ou de leurs modifications.
                 </div>
               </div>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">4. Obligations de l&apos;Utilisateur</h2>
-                
+
                 <h3 className="h5 mb-2">4.1 Usage Conforme</h3>
-                <p>Vous vous engagez a :</p>
+                <p>Vous vous engagez à :</p>
                 <ul className="mb-3">
-                  <li>Utiliser la plateforme dans le respect de la legislation</li>
+                  <li>Utiliser la plateforme dans le respect de la législation</li>
                   <li>Ne pas porter atteinte aux droits de tiers</li>
-                  <li>Maintenir la confidentialite de vos identifiants</li>
-                  <li>Signaler toute utilisation non autorisee de votre compte</li>
+                  <li>Maintenir la confidentialité de vos identifiants</li>
+                  <li>Signaler toute utilisation non autorisée de votre compte</li>
                 </ul>
 
-                <h3 className="h5 mb-2">4.2 Donnees Fiscales</h3>
-                <p>Concernant vos donnees fiscales, vous devez :</p>
+                <h3 className="h5 mb-2">4.2 Données de Facturation</h3>
+                <p>Concernant vos données de facturation, vous devez :</p>
                 <ul>
-                  <li>Fournir des informations exactes et completes</li>
-                  <li>Verifier la coherence des donnees synchronisees</li>
-                  <li>Conserver vos justificatifs selon la reglementation</li>
-                  <li>Assumer la responsabilite finale de vos declarations</li>
+                  <li>Fournir des informations exactes et complètes</li>
+                  <li>Vérifier la cohérence des données avant émission</li>
+                  <li>Conserver vos justificatifs selon la réglementation</li>
+                  <li>Assumer la responsabilité finale de vos factures émises</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">5. Assistant IA et Conseils Automatises</h2>
-                
-                <h3 className="h5 mb-2">5.1 Nature des Conseils</h3>
+                <h2 className="h4 mb-3">5. IA et Extraction Automatique</h2>
+
+                <h3 className="h5 mb-2">5.1 Nature du Service</h3>
                 <p>
-                  L&apos;assistant IA fournit des conseils bases sur vos donnees et les reglementations en vigueur. 
-                  Ces conseils sont informatifs et ne constituent pas un avis juridique ou comptable personnalise.
+                  InvoiceOps utilise l&apos;IA pour extraire et structurer des données de facturation.
+                  Ces extractions sont indicatives — vous devez vérifier et valider les données avant émission.
                 </p>
 
-                <h3 className="h5 mb-2">5.2 Responsabilite</h3>
+                <h3 className="h5 mb-2">5.2 Responsabilité</h3>
                 <ul className="mb-3">
-                  <li>Vous devez verifier et valider tous les conseils recus</li>
-                  <li>Consulter un professionnel pour les situations complexes</li>
-                  <li>L&apos;IA peut commettre des erreurs ou être incomplete</li>
+                  <li>Vous devez vérifier et valider toutes les données extraites</li>
+                  <li>L&apos;IA peut commettre des erreurs ou être incomplète</li>
+                  <li>La conformité finale de chaque facture relève de votre responsabilité</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">6. Protection des Donnees</h2>
+                <h2 className="h4 mb-3">6. Protection des Données</h2>
                 <p>
-                  Le traitement de vos donnees personnelles est regi par notre{' '}
-                  <a href="/privacy-policy" className="text-decoration-none">Politique de Confidentialite</a>, 
-                  qui fait partie integrante des presentes CGU.
+                  Le traitement de vos données personnelles est régi par notre{' '}
+                  <a href="/privacy-policy" className="text-decoration-none">Politique de Confidentialité</a>,
+                  qui fait partie intégrante des présentes CGU.
                 </p>
-                
-                <h3 className="h5 mb-2">6.1 Securite</h3>
+
+                <h3 className="h5 mb-2">6.1 Sécurité</h3>
                 <ul className="mb-3">
                   <li>Chiffrement de toutes les communications</li>
-                  <li>Authentification securisee</li>
-                  <li>Sauvegardes regulieres et chiffrees</li>
-                  <li>Acces restreint aux donnees sensibles</li>
+                  <li>Authentification sécurisée</li>
+                  <li>Sauvegardes régulières et chiffrées</li>
+                  <li>Accès restreint aux données sensibles</li>
                 </ul>
               </div>
 
               <div className="mb-5">
-                <h2 className="h4 mb-3">7. Limitation de Responsabilite</h2>
+                <h2 className="h4 mb-3">7. Limitation de Responsabilité</h2>
                 <div className="alert alert-info">
-                  <p><strong>Important :</strong> InvoiceOps est un outil d&apos;aide a la gestion fiscale. 
+                  <p><strong>Important :</strong> InvoiceOps est un outil d&apos;automatisation du workflow de facturation.
                   Vous restez seul responsable de :</p>
                   <ul className="mb-0">
-                    <li>L&apos;exactitude de vos declarations fiscales</li>
-                    <li>Le respect des obligations legales</li>
-                    <li>La validation des conseils automatises</li>
-                    <li>La sauvegarde de vos donnees importantes</li>
+                    <li>L&apos;exactitude de vos factures émises</li>
+                    <li>Le respect des obligations légales de facturation</li>
+                    <li>La validation des données extraites automatiquement</li>
+                    <li>La sauvegarde de vos données importantes</li>
                   </ul>
                 </div>
               </div>
 
               <div className="mb-5">
                 <h2 className="h4 mb-3">8. Contact et Support</h2>
-                
+
                 <div className="row">
                   <div className="col-md-6">
                     <h3 className="h6">Support Technique</h3>
@@ -163,9 +163,8 @@ export default function TermsOfServicePage() {
                   Engagement InvoiceOps
                 </h4>
                 <p className="mb-0">
-                  Nous nous engageons a fournir un service de qualite, respectueux de vos donnees 
-                  et conforme a la reglementation francaise et europeenne. Notre equipe reste 
-                  disponible pour repondre a vos questions et ameliorer continuellement la plateforme.
+                  Nous nous engageons à fournir un service de qualité, respectueux de vos données
+                  et conforme à la réglementation française et européenne sur la facturation électronique.
                 </p>
               </div>
 
@@ -175,11 +174,11 @@ export default function TermsOfServicePage() {
                 </p>
                 <Link href="/" className="btn btn-primary me-3">
                   <i className="bi bi-house me-2"></i>
-                  Retour a l&apos;accueil
+                  Retour à l&apos;accueil
                 </Link>
                 <Link href="/privacy-policy" className="btn btn-outline-secondary me-3">
                   <i className="bi bi-shield-check me-2"></i>
-                  Politique de Confidentialite
+                  Politique de Confidentialité
                 </Link>
                 <Link href="/dashboard" className="btn btn-outline-primary">
                   <i className="bi bi-speedometer2 me-2"></i>


### PR DESCRIPTION
## Summary

- Promotes the InvoiceOps pivot copy cleanup into staging
- Removes all pre-pivot Splitfact/URSSAF/micro-entrepreneur content from every user-facing page and component
- All CI checks green on PR #16; Vercel preview deployed cleanly

## Included changes

- Sidebar, sign-in, offline, notifications, settings pages — brand and copy updated to InvoiceOps
- Landing page ICP section, pivot quote, compliance feature cards
- README, privacy policy, terms of service — full InvoiceOps alignment

## Test plan

- [ ] Verify Vercel staging preview renders correctly
- [ ] Sign-in page shows pivot-aligned features
- [ ] Notifications page renders without TypeScript errors
- [ ] Settings page no longer shows MicroBIC/BNC or URSSAF fields