### PR TITLE
feat: PPF receive inbox — Sep 2026 e-invoicing receive compliance

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model User {
   billingTriggers       BillingTrigger[]
   eReportingPeriods     EReportingPeriod[]
   complianceEvents      ComplianceEvent[]
+  receivedInvoices      ReceivedInvoice[]
 }
 
 model VerificationToken {
@@ -243,6 +244,7 @@ enum NotificationType {
   FISCAL_INSIGHT
   DEADLINE
   CASH_FLOW
+  INVOICE_RECEIVED
 }
 
 
@@ -404,6 +406,29 @@ enum EReportingStatus {
   submitted
   accepted
   rejected
+}
+
+model ReceivedInvoice {
+  id              String    @id @default(cuid())
+  userId          String
+  user            User      @relation(fields: [userId], references: [id])
+  cppId           String    @unique  // identifiantFactureCPP from Chorus Pro
+  invoiceNumber   String
+  supplierName    String
+  supplierSiret   String?
+  buyerSiret      String?
+  totalAmountTTC  Decimal   @default(0)
+  currency        String    @default("EUR")
+  invoiceDate     DateTime?
+  depositedAt     DateTime?
+  ppfStatus       String    @default("RECUE")
+  rawXml          String?   @db.Text
+  isRead          Boolean   @default(false)
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@index([userId, createdAt])
+  @@index([cppId])
 }
 
 model SireneCache {

--- a/src/app/api/cron/ppf-receive/route.ts
+++ b/src/app/api/cron/ppf-receive/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { fetchReceivedInvoicesFromPpf, downloadReceivedInvoiceXml } from '@/lib/piste-api';
+
+// GET /api/cron/ppf-receive
+// Polls Chorus Pro for invoices received since yesterday, stores new ones, notifies users.
+// Called by Vercel cron daily at 07:00.
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('Authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const toDate = new Date();
+  const fromDate = new Date(toDate);
+  fromDate.setDate(fromDate.getDate() - 2); // 48h window to avoid gaps
+
+  const fromStr = fromDate.toISOString().split('T')[0];
+  const toStr = toDate.toISOString().split('T')[0];
+
+  const fetched = await fetchReceivedInvoicesFromPpf({ fromDate: fromStr, toDate: toStr });
+
+  if (!fetched.success) {
+    return NextResponse.json({ error: fetched.error }, { status: 502 });
+  }
+
+  if (fetched.invoices.length === 0) {
+    return NextResponse.json({ created: 0, skipped: 0 });
+  }
+
+  // Build a SIRET → userId index for fast lookup
+  const usersWithSiret = await prisma.user.findMany({
+    where: { siret: { not: null } },
+    select: { id: true, siret: true },
+  });
+  const siretToUserId = new Map(usersWithSiret.map((u) => [u.siret!, u.id]));
+
+  // Check which cppIds already exist so we skip duplicates
+  const incomingCppIds = fetched.invoices.map((i) => i.cppId).filter(Boolean);
+  const existing = await prisma.receivedInvoice.findMany({
+    where: { cppId: { in: incomingCppIds } },
+    select: { cppId: true },
+  });
+  const existingSet = new Set(existing.map((e) => e.cppId));
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const inv of fetched.invoices) {
+    if (!inv.cppId || existingSet.has(inv.cppId)) { skipped++; continue; }
+
+    const userId = inv.buyerSiret ? siretToUserId.get(inv.buyerSiret) : undefined;
+    if (!userId) { skipped++; continue; } // no matching user for this SIRET
+
+    // Best-effort XML download — don't block on failure
+    const rawXml = await downloadReceivedInvoiceXml(inv.cppId).catch(() => null);
+
+    await prisma.receivedInvoice.create({
+      data: {
+        userId,
+        cppId: inv.cppId,
+        invoiceNumber: inv.invoiceNumber,
+        supplierName: inv.supplierName,
+        supplierSiret: inv.supplierSiret,
+        buyerSiret: inv.buyerSiret,
+        totalAmountTTC: inv.totalAmountTTC,
+        ppfStatus: inv.ppfStatus,
+        depositedAt: inv.depositedAt ? new Date(inv.depositedAt) : null,
+        rawXml: rawXml ?? null,
+      },
+    });
+
+    await prisma.notification.create({
+      data: {
+        userId,
+        type: 'INVOICE_RECEIVED',
+        title: `Facture reçue — ${inv.supplierName}`,
+        message: `Facture n° ${inv.invoiceNumber} de ${inv.supplierName} (${inv.totalAmountTTC.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })}) disponible dans votre inbox.`,
+        actionUrl: '/dashboard/received-invoices',
+        metadata: { cppId: inv.cppId, supplierSiret: inv.supplierSiret },
+      },
+    });
+
+    created++;
+  }
+
+  return NextResponse.json({ created, skipped, total: fetched.total });
+}

--- a/src/app/api/received-invoices/[id]/route.ts
+++ b/src/app/api/received-invoices/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+// PATCH /api/received-invoices/[id] — mark as read
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const inv = await prisma.receivedInvoice.findFirst({
+    where: { id: params.id, userId: session.user.id },
+  });
+  if (!inv) return new NextResponse('Not found', { status: 404 });
+
+  await prisma.receivedInvoice.update({
+    where: { id: params.id },
+    data: { isRead: true },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+// GET /api/received-invoices/[id] — fetch detail + XML
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const inv = await prisma.receivedInvoice.findFirst({
+    where: { id: params.id, userId: session.user.id },
+  });
+  if (!inv) return new NextResponse('Not found', { status: 404 });
+
+  return NextResponse.json(inv);
+}

--- a/src/app/api/received-invoices/[id]/route.ts
+++ b/src/app/api/received-invoices/[id]/route.ts
@@ -6,20 +6,21 @@ import { prisma } from '@/lib/prisma';
 // PATCH /api/received-invoices/[id] — mark as read
 export async function PATCH(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 
+  const { id } = await params;
   const inv = await prisma.receivedInvoice.findFirst({
-    where: { id: params.id, userId: session.user.id },
+    where: { id, userId: session.user.id },
   });
   if (!inv) return new NextResponse('Not found', { status: 404 });
 
   await prisma.receivedInvoice.update({
-    where: { id: params.id },
+    where: { id },
     data: { isRead: true },
   });
 
@@ -28,16 +29,17 @@ export async function PATCH(
 
 // GET /api/received-invoices/[id] — fetch detail + XML
 export async function GET(
-  request: Request,
-  { params }: { params: { id: string } }
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 
+  const { id } = await params;
   const inv = await prisma.receivedInvoice.findFirst({
-    where: { id: params.id, userId: session.user.id },
+    where: { id, userId: session.user.id },
   });
   if (!inv) return new NextResponse('Not found', { status: 404 });
 

--- a/src/app/api/received-invoices/route.ts
+++ b/src/app/api/received-invoices/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+// GET /api/received-invoices?unread=true&limit=50&page=1
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const unreadOnly = searchParams.get('unread') === 'true';
+  const limit = Math.min(Number(searchParams.get('limit') ?? 50), 100);
+  const page = Math.max(Number(searchParams.get('page') ?? 1), 1);
+
+  const where = {
+    userId: session.user.id,
+    ...(unreadOnly ? { isRead: false } : {}),
+  };
+
+  const [invoices, total] = await Promise.all([
+    prisma.receivedInvoice.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: (page - 1) * limit,
+      select: {
+        id: true,
+        cppId: true,
+        invoiceNumber: true,
+        supplierName: true,
+        supplierSiret: true,
+        totalAmountTTC: true,
+        currency: true,
+        invoiceDate: true,
+        depositedAt: true,
+        ppfStatus: true,
+        isRead: true,
+        createdAt: true,
+      },
+    }),
+    prisma.receivedInvoice.count({ where }),
+  ]);
+
+  return NextResponse.json({ invoices, total, page, limit });
+}
+
+// PATCH /api/received-invoices — mark all as read
+export async function PATCH(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  await prisma.receivedInvoice.updateMany({
+    where: { userId: session.user.id, isRead: false },
+    data: { isRead: true },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -8,9 +8,10 @@ import { FeedbackMenuItem } from "./FeedbackButton";
 const NAV = {
   main:       [{ name: "Tableau de bord", href: "/dashboard", icon: "bi-grid" }],
   invoicing:  [
-    { name: "Factures",         href: "/dashboard/invoices",       icon: "bi-receipt" },
-    { name: "Exceptions",       href: "/dashboard/exceptions",     icon: "bi-exclamation-diamond" },
-    { name: "Nouvelle facture", href: "/dashboard/create-invoice", icon: "bi-file-earmark-plus" },
+    { name: "Factures",         href: "/dashboard/invoices",           icon: "bi-receipt" },
+    { name: "Factures reçues",  href: "/dashboard/received-invoices",  icon: "bi-inbox" },
+    { name: "Exceptions",       href: "/dashboard/exceptions",         icon: "bi-exclamation-diamond" },
+    { name: "Nouvelle facture", href: "/dashboard/create-invoice",     icon: "bi-file-earmark-plus" },
   ],
   operations: [
     { name: "Clients",       href: "/dashboard/clients",       icon: "bi-person-vcard" },

--- a/src/app/dashboard/received-invoices/page.tsx
+++ b/src/app/dashboard/received-invoices/page.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface ReceivedInvoice {
+  id: string;
+  cppId: string;
+  invoiceNumber: string;
+  supplierName: string;
+  supplierSiret: string | null;
+  totalAmountTTC: number;
+  currency: string;
+  invoiceDate: string | null;
+  depositedAt: string | null;
+  ppfStatus: string;
+  isRead: boolean;
+  createdAt: string;
+}
+
+const STATUS_BADGE: Record<string, { label: string; color: string }> = {
+  DEPOSEE:            { label: 'Déposée',       color: 'bg-secondary' },
+  EN_COURS_DE_ROUTAGE:{ label: 'En routage',    color: 'bg-info' },
+  RECUE:              { label: 'Reçue',          color: 'bg-success' },
+  REJETEE:            { label: 'Rejetée',        color: 'bg-danger' },
+  REFUSEE:            { label: 'Refusée',        color: 'bg-danger' },
+  APPROUVEE:          { label: 'Approuvée',      color: 'bg-primary' },
+  PAYEE:              { label: 'Payée',          color: 'bg-success' },
+};
+
+function fmtAmount(amount: number, currency = 'EUR') {
+  return amount.toLocaleString('fr-FR', { style: 'currency', currency });
+}
+
+function fmtDate(iso: string | null) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+export default function ReceivedInvoicesPage() {
+  const [invoices, setInvoices] = useState<ReceivedInvoice[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'all' | 'unread'>('all');
+
+  const unreadCount = invoices.filter((i) => !i.isRead).length;
+
+  const fetchInvoices = async () => {
+    setLoading(true);
+    try {
+      const url = filter === 'unread'
+        ? '/api/received-invoices?unread=true&limit=100'
+        : '/api/received-invoices?limit=100';
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        setInvoices(data.invoices);
+        setTotal(data.total);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchInvoices(); }, [filter]);
+
+  const markRead = async (id: string) => {
+    await fetch(`/api/received-invoices/${id}`, { method: 'PATCH' });
+    setInvoices((prev) => prev.map((i) => i.id === id ? { ...i, isRead: true } : i));
+  };
+
+  const markAllRead = async () => {
+    await fetch('/api/received-invoices', { method: 'PATCH' });
+    setInvoices((prev) => prev.map((i) => ({ ...i, isRead: true })));
+  };
+
+  return (
+    <div className="main-container">
+      {/* Header */}
+      <div className="d-flex justify-content-between align-items-start mb-4">
+        <div>
+          <h1 className="h2 mb-1">
+            <i className="bi bi-inbox me-2"></i>
+            Factures reçues
+          </h1>
+          <p className="text-muted mb-0">
+            Factures entrantes via Chorus Pro (PPF) — conformité réforme Sep 2026
+          </p>
+        </div>
+        {unreadCount > 0 && (
+          <button className="btn btn-outline-primary" onClick={markAllRead}>
+            <i className="bi bi-check-all me-1"></i>
+            Tout marquer lu
+          </button>
+        )}
+      </div>
+
+      {/* Stats bar */}
+      <div className="row g-3 mb-4">
+        <div className="col-md-4">
+          <div className="card shadow-sm text-center py-3">
+            <div className="h3 fw-bold text-primary mb-0">{total}</div>
+            <small className="text-muted">Factures reçues</small>
+          </div>
+        </div>
+        <div className="col-md-4">
+          <div className="card shadow-sm text-center py-3">
+            <div className="h3 fw-bold text-warning mb-0">{unreadCount}</div>
+            <small className="text-muted">Non lues</small>
+          </div>
+        </div>
+        <div className="col-md-4">
+          <div className="card shadow-sm text-center py-3">
+            <div className="h3 fw-bold text-success mb-0">
+              {invoices.filter((i) => i.ppfStatus === 'RECUE' || i.ppfStatus === 'APPROUVEE').length}
+            </div>
+            <small className="text-muted">Statut conforme</small>
+          </div>
+        </div>
+      </div>
+
+      {/* Filter */}
+      <div className="card shadow-subtle mb-4">
+        <div className="card-body p-2">
+          <div className="btn-group w-100" role="group">
+            <input type="radio" className="btn-check" name="recv-filter" id="recv-all"
+              checked={filter === 'all'} onChange={() => setFilter('all')} />
+            <label className="btn btn-outline-primary" htmlFor="recv-all">
+              <i className="bi bi-list me-1"></i>Toutes ({total})
+            </label>
+            <input type="radio" className="btn-check" name="recv-filter" id="recv-unread"
+              checked={filter === 'unread'} onChange={() => setFilter('unread')} />
+            <label className="btn btn-outline-primary" htmlFor="recv-unread">
+              <i className="bi bi-dot me-1"></i>Non lues ({unreadCount})
+            </label>
+          </div>
+        </div>
+      </div>
+
+      {/* List */}
+      <div className="card shadow-subtle">
+        <div className="card-body p-0">
+          {loading ? (
+            <div className="text-center py-5">
+              <div className="spinner-border text-primary" role="status">
+                <span className="visually-hidden">Chargement...</span>
+              </div>
+            </div>
+          ) : invoices.length === 0 ? (
+            <div className="text-center py-5">
+              <i className="bi bi-inbox display-1 text-muted mb-3"></i>
+              <h5 className="text-muted">
+                {filter === 'unread' ? 'Aucune facture non lue' : 'Aucune facture reçue'}
+              </h5>
+              <p className="text-muted">
+                Les factures envoyées par vos fournisseurs via Chorus Pro apparaîtront ici.
+              </p>
+              <small className="text-muted">
+                <i className="bi bi-info-circle me-1"></i>
+                La synchronisation s'effectue chaque nuit à 07h00.
+              </small>
+            </div>
+          ) : (
+            <div className="list-group list-group-flush">
+              {invoices.map((inv) => {
+                const badge = STATUS_BADGE[inv.ppfStatus] ?? { label: inv.ppfStatus, color: 'bg-secondary' };
+                return (
+                  <div
+                    key={inv.id}
+                    className={`list-group-item position-relative ${!inv.isRead ? 'bg-light border-start border-primary border-3' : ''}`}
+                  >
+                    <div className="d-flex align-items-start gap-3">
+                      <div className={`mt-1 ${!inv.isRead ? 'text-primary' : 'text-muted'}`}>
+                        <i className="bi bi-file-earmark-arrow-down fs-4"></i>
+                      </div>
+                      <div className="flex-grow-1 min-w-0">
+                        <div className="d-flex justify-content-between align-items-start mb-1">
+                          <h6 className={`mb-0 ${!inv.isRead ? 'fw-bold' : ''}`}>
+                            {inv.supplierName}
+                          </h6>
+                          <div className="d-flex align-items-center gap-2 ms-2 flex-shrink-0">
+                            <span className={`badge ${badge.color} text-white`}>{badge.label}</span>
+                            {!inv.isRead && <span className="badge bg-primary">Nouveau</span>}
+                          </div>
+                        </div>
+
+                        <div className="d-flex flex-wrap gap-3 text-muted small mb-2">
+                          <span>
+                            <i className="bi bi-hash me-1"></i>
+                            {inv.invoiceNumber || '—'}
+                          </span>
+                          {inv.supplierSiret && (
+                            <span>
+                              <i className="bi bi-building me-1"></i>
+                              SIRET {inv.supplierSiret}
+                            </span>
+                          )}
+                          <span>
+                            <i className="bi bi-calendar3 me-1"></i>
+                            Reçue le {fmtDate(inv.depositedAt ?? inv.createdAt)}
+                          </span>
+                        </div>
+
+                        <div className="d-flex justify-content-between align-items-center">
+                          <span className="fw-semibold text-dark">
+                            {fmtAmount(Number(inv.totalAmountTTC), inv.currency)}
+                          </span>
+                          <div className="btn-group btn-group-sm">
+                            {!inv.isRead && (
+                              <button
+                                className="btn btn-outline-primary"
+                                onClick={() => markRead(inv.id)}
+                                title="Marquer comme lu"
+                              >
+                                <i className="bi bi-check"></i>
+                              </button>
+                            )}
+                            <button
+                              className="btn btn-outline-secondary"
+                              onClick={async () => {
+                                const res = await fetch(`/api/received-invoices/${inv.id}`);
+                                const data = await res.json();
+                                if (data.rawXml) {
+                                  const blob = new Blob([data.rawXml], { type: 'application/xml' });
+                                  const url = URL.createObjectURL(blob);
+                                  const a = document.createElement('a');
+                                  a.href = url;
+                                  a.download = `${inv.invoiceNumber || inv.cppId}.xml`;
+                                  a.click();
+                                  URL.revokeObjectURL(url);
+                                } else {
+                                  alert('XML non disponible pour cette facture.');
+                                }
+                                if (!inv.isRead) markRead(inv.id);
+                              }}
+                              title="Télécharger XML Factur-X"
+                            >
+                              <i className="bi bi-download me-1"></i>XML
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Info callout */}
+      <div className="alert alert-info mt-4">
+        <i className="bi bi-info-circle me-2"></i>
+        <strong>Réforme e-invoicing — Sep 2026 :</strong> Toute entreprise assujettie à la TVA doit être capable
+        de recevoir des factures électroniques. Cette inbox centralise les factures entrantes depuis Chorus Pro.
+      </div>
+    </div>
+  );
+}

--- a/src/lib/piste-api.ts
+++ b/src/lib/piste-api.ts
@@ -221,4 +221,98 @@ export function mapPpfStatus(ppfStatus: PpfLifecycleStatus): string {
   return map[ppfStatus] ?? 'deposee';
 }
 
+// ─── Fetch invoices received via PPF (destinataire search) ───────────────────
+
+export interface ReceivedInvoiceEntry {
+  cppId: string;
+  invoiceNumber: string;
+  supplierName: string;
+  supplierSiret: string | null;
+  buyerSiret: string | null;
+  totalAmountTTC: number;
+  ppfStatus: string;
+  depositedAt: string | null; // ISO string
+}
+
+export interface FetchReceivedInvoicesResult {
+  success: boolean;
+  invoices: ReceivedInvoiceEntry[];
+  total: number;
+  error?: string;
+}
+
+export async function fetchReceivedInvoicesFromPpf(opts: {
+  fromDate: string; // YYYY-MM-DD
+  toDate: string;   // YYYY-MM-DD
+  page?: number;
+}): Promise<FetchReceivedInvoicesResult> {
+  try {
+    const token = await getAccessToken();
+    const cproAccount = getCproAccountHeader();
+
+    const res = await fetch(`${PISTE_BASE}/cpro/factures/v1/rechercher/destinataire`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'cpro-account': cproAccount,
+        'Content-Type': 'application/json;charset=utf-8',
+      },
+      body: JSON.stringify({
+        dateDepotFactureDu: opts.fromDate,
+        dateDepotFactureAu: opts.toDate,
+        nbResultatsParPage: 50,
+        pageResultat: opts.page ?? 1,
+      }),
+    });
+
+    const json = await res.json().catch(() => ({})) as any;
+
+    if (!res.ok || (json?.codeRetour !== 0 && json?.codeRetour !== undefined)) {
+      return { success: false, invoices: [], total: 0, error: json?.libelle ?? `PISTE error ${res.status}` };
+    }
+
+    const raw: any[] = json?.listeFactures ?? [];
+    const invoices: ReceivedInvoiceEntry[] = raw.map((f) => ({
+      cppId: String(f.identifiantFactureCPP ?? ''),
+      invoiceNumber: f.numeroFacture ?? '',
+      supplierName: f.nomFournisseur ?? 'Fournisseur inconnu',
+      supplierSiret: f.siretFournisseur ?? null,
+      buyerSiret: f.siretDestinataire ?? null,
+      totalAmountTTC: Number(f.montantTTC ?? 0),
+      ppfStatus: f.statut ?? 'RECUE',
+      depositedAt: f.dateDepot ?? null,
+    }));
+
+    return { success: true, invoices, total: json?.nbTotalResultats ?? invoices.length };
+  } catch (err: any) {
+    return { success: false, invoices: [], total: 0, error: err?.message ?? 'PISTE fetch failed' };
+  }
+}
+
+// ─── Download raw XML for a received invoice ──────────────────────────────────
+
+export async function downloadReceivedInvoiceXml(cppId: string): Promise<string | null> {
+  try {
+    const token = await getAccessToken();
+    const cproAccount = getCproAccountHeader();
+
+    const res = await fetch(`${PISTE_BASE}/cpro/factures/v1/telecharger`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'cpro-account': cproAccount,
+        'Content-Type': 'application/json;charset=utf-8',
+      },
+      body: JSON.stringify({ identifiantFactureCPP: Number(cppId), telechargerToutesVersions: false }),
+    });
+
+    const json = await res.json().catch(() => ({})) as any;
+    if (!res.ok || !json?.fichierFacture) return null;
+
+    return Buffer.from(json.fichierFacture, 'base64').toString('utf-8');
+  } catch {
+    return null;
+  }
+}
+
 export { ENV as PISTE_ENV };

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,10 @@
     {
       "path": "/api/cron/e-reporting",
       "schedule": "0 6 2 * *"
+    },
+    {
+      "path": "/api/cron/ppf-receive",
+      "schedule": "0 7 * * *"
     }
   ],
   "functions": {
@@ -37,6 +41,9 @@
       "maxDuration": 60
     },
     "src/app/api/cron/e-reporting/route.ts": {
+      "maxDuration": 60
+    },
+    "src/app/api/cron/ppf-receive/route.ts": {
       "maxDuration": 60
     }
   }


### PR DESCRIPTION
## Summary

Implements the receiving side of the French e-invoicing reform (Sep 2026 deadline).

- **`ReceivedInvoice` Prisma model** — stores incoming invoices from Chorus Pro with deduplication by `cppId`
- **PISTE API** — `fetchReceivedInvoicesFromPpf()` polls `rechercher/destinataire`; `downloadReceivedInvoiceXml()` fetches the Factur-X XML via `telecharger`
- **Cron `ppf-receive`** (daily 07:00) — fetches last 48h window, matches users by `siretDestinataire` → `User.siret`, creates `ReceivedInvoice` records + `INVOICE_RECEIVED` notifications
- **`/api/received-invoices`** — list + mark-all-read endpoints
- **`/api/received-invoices/[id]`** — detail (includes raw XML) + mark-read
- **`/dashboard/received-invoices`** — inbox page: PPF status badges, XML download, unread filter, compliance callout
- **Sidebar** — "Factures reçues" nav entry under invoicing section
- **`vercel.json`** — cron registered at `0 7 * * *`

## Schema migration

Run before deploying:
```bash
nvm use 20 && npx prisma db push
```

## Test plan

- [ ] `/dashboard/received-invoices` renders with empty state
- [ ] `GET /api/received-invoices` returns 200
- [ ] `PATCH /api/received-invoices` marks all read
- [ ] Cron endpoint returns 401 without CRON_SECRET
- [ ] Cron endpoint returns `{ created, skipped }` with valid auth (sandbox)