### PR TITLE
feat: reform readiness widget (e-invoicing Sep 2026/2027)

### DIFF
--- a/src/app/api/reform-readiness/route.ts
+++ b/src/app/api/reform-readiness/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+const RECEIVE_DEADLINE = new Date('2026-09-01T00:00:00Z');
+const EMIT_DEADLINE = new Date('2027-09-01T00:00:00Z');
+
+function daysUntil(target: Date): number {
+  return Math.max(0, Math.ceil((target.getTime() - Date.now()) / 86_400_000));
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { siret: true, siretValidated: true },
+  });
+
+  const hasCproCredentials =
+    !!(process.env.CPRO_TECH_LOGIN && process.env.CPRO_TECH_PASSWORD);
+  const hasPisteCredentials =
+    !!(process.env.PISTE_CLIENT_ID && process.env.PISTE_CLIENT_SECRET);
+  const hasSiret = !!(user?.siret && user.siretValidated);
+
+  return NextResponse.json({
+    receive: {
+      ready: hasCproCredentials,
+      checks: {
+        cproCredentials: hasCproCredentials,
+      },
+      deadlineDate: RECEIVE_DEADLINE.toISOString(),
+      daysRemaining: daysUntil(RECEIVE_DEADLINE),
+    },
+    emit: {
+      ready: hasPisteCredentials && hasSiret,
+      checks: {
+        pisteCredentials: hasPisteCredentials,
+        siretValidated: hasSiret,
+      },
+      deadlineDate: EMIT_DEADLINE.toISOString(),
+      daysRemaining: daysUntil(EMIT_DEADLINE),
+    },
+  });
+}

--- a/src/app/api/reform-readiness/route.ts
+++ b/src/app/api/reform-readiness/route.ts
@@ -18,14 +18,14 @@ export async function GET() {
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { siret: true, siretValidated: true },
+    select: { siret: true },
   });
 
   const hasCproCredentials =
     !!(process.env.CPRO_TECH_LOGIN && process.env.CPRO_TECH_PASSWORD);
   const hasPisteCredentials =
     !!(process.env.PISTE_CLIENT_ID && process.env.PISTE_CLIENT_SECRET);
-  const hasSiret = !!(user?.siret && user.siretValidated);
+  const hasSiret = !!user?.siret;
 
   return NextResponse.json({
     receive: {

--- a/src/app/components/ReformReadinessWidget.tsx
+++ b/src/app/components/ReformReadinessWidget.tsx
@@ -102,7 +102,7 @@ function DeadlineBlock({ label, data }: { label: string; data: ReadinessCheck })
           const labels: Record<string, string> = {
             cproCredentials: 'Compte technique Chorus Pro',
             pisteCredentials: 'Credentials PISTE API',
-            siretValidated: 'SIRET validé',
+            siretValidated: 'SIRET renseigné',
           };
           return <CheckRow key={key} label={labels[key] ?? key} ok={ok} />;
         })}

--- a/src/app/components/ReformReadinessWidget.tsx
+++ b/src/app/components/ReformReadinessWidget.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface ReadinessCheck {
+  ready: boolean;
+  checks: Record<string, boolean>;
+  deadlineDate: string;
+  daysRemaining: number;
+}
+
+interface ReformReadiness {
+  receive: ReadinessCheck;
+  emit: ReadinessCheck;
+}
+
+function urgencyColor(days: number, ready: boolean): string {
+  if (ready) return '#16a34a';
+  if (days < 90) return '#dc2626';
+  if (days < 180) return '#d97706';
+  return '#6b7280';
+}
+
+function urgencyBg(days: number, ready: boolean): string {
+  if (ready) return 'rgba(22,163,74,0.08)';
+  if (days < 90) return 'rgba(220,38,38,0.06)';
+  if (days < 180) return 'rgba(217,119,6,0.06)';
+  return 'rgba(107,114,128,0.06)';
+}
+
+function CheckRow({ label, ok }: { label: string; ok: boolean }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '0.8125rem', color: ok ? '#d0d6e0' : '#8a8f98' }}>
+      <i
+        className={`bi ${ok ? 'bi-check-circle-fill' : 'bi-x-circle-fill'}`}
+        style={{ color: ok ? '#16a34a' : '#dc2626', fontSize: '0.75rem', flexShrink: 0 }}
+      />
+      {label}
+    </div>
+  );
+}
+
+function DeadlineBlock({ label, data }: { label: string; data: ReadinessCheck }) {
+  const color = urgencyColor(data.daysRemaining, data.ready);
+  const bg = urgencyBg(data.daysRemaining, data.ready);
+  const deadline = new Date(data.deadlineDate).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+
+  return (
+    <div style={{
+      flex: 1,
+      borderRadius: '8px',
+      border: `1px solid ${color}30`,
+      backgroundColor: bg,
+      padding: '14px 16px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '10px',
+    }}>
+      {/* Header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div>
+          <div style={{ fontSize: '0.6875rem', fontWeight: 590, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#62666d' }}>
+            {label}
+          </div>
+          <div style={{ fontSize: '0.8125rem', color: '#8a8f98', marginTop: '2px' }}>
+            Obligatoire · {deadline}
+          </div>
+        </div>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          backgroundColor: `${color}15`,
+          border: `1px solid ${color}30`,
+          borderRadius: '6px',
+          padding: '4px 8px',
+        }}>
+          <i
+            className={`bi ${data.ready ? 'bi-shield-check' : 'bi-shield-exclamation'}`}
+            style={{ color, fontSize: '0.875rem' }}
+          />
+          <span style={{ fontSize: '0.75rem', fontWeight: 590, color }}>
+            {data.ready ? 'Configuré' : 'Non configuré'}
+          </span>
+        </div>
+      </div>
+
+      {/* Countdown */}
+      {!data.ready && (
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
+          <span style={{ fontSize: '1.5rem', fontWeight: 700, color, lineHeight: 1 }}>
+            {data.daysRemaining}
+          </span>
+          <span style={{ fontSize: '0.75rem', color: '#8a8f98' }}>jours restants</span>
+        </div>
+      )}
+
+      {/* Checks */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+        {Object.entries(data.checks).map(([key, ok]) => {
+          const labels: Record<string, string> = {
+            cproCredentials: 'Compte technique Chorus Pro',
+            pisteCredentials: 'Credentials PISTE API',
+            siretValidated: 'SIRET validé',
+          };
+          return <CheckRow key={key} label={labels[key] ?? key} ok={ok} />;
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default function ReformReadinessWidget() {
+  const [data, setData] = useState<ReformReadiness | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/reform-readiness')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (loading) return null;
+  if (!data) return null;
+
+  const allReady = data.receive.ready && data.emit.ready;
+  const urgentIssue = !data.receive.ready && data.receive.daysRemaining < 180;
+
+  return (
+    <div style={{
+      borderRadius: '10px',
+      border: `1px solid ${urgentIssue ? 'rgba(220,38,38,0.2)' : 'rgba(255,255,255,0.07)'}`,
+      backgroundColor: '#141517',
+      padding: '16px',
+      marginBottom: '24px',
+    }}>
+      {/* Widget header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '14px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <i className="bi bi-patch-check" style={{ color: '#D4921A', fontSize: '1rem' }} />
+          <span style={{ fontSize: '0.875rem', fontWeight: 590, color: '#d0d6e0' }}>
+            Conformité Réforme E-Invoicing
+          </span>
+          {urgentIssue && (
+            <span style={{
+              fontSize: '0.6875rem',
+              fontWeight: 590,
+              backgroundColor: 'rgba(220,38,38,0.12)',
+              color: '#dc2626',
+              border: '1px solid rgba(220,38,38,0.25)',
+              borderRadius: '4px',
+              padding: '1px 6px',
+              letterSpacing: '0.04em',
+            }}>
+              URGENT
+            </span>
+          )}
+        </div>
+        {allReady ? (
+          <span style={{ fontSize: '0.75rem', color: '#16a34a' }}>
+            <i className="bi bi-check-all me-1" />
+            Prêt
+          </span>
+        ) : (
+          <Link href="/dashboard/settings" style={{ fontSize: '0.75rem', color: '#D4921A', textDecoration: 'none' }}>
+            Configurer <i className="bi bi-arrow-right ms-1" />
+          </Link>
+        )}
+      </div>
+
+      {/* Two deadline blocks side by side */}
+      <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+        <DeadlineBlock label="Réception (Sep 2026)" data={data.receive} />
+        <DeadlineBlock label="Émission (Sep 2027)" data={data.emit} />
+      </div>
+
+      {/* Footer note */}
+      {!allReady && (
+        <div style={{ marginTop: '12px', fontSize: '0.75rem', color: '#62666d', display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <i className="bi bi-info-circle" />
+          Configurez vos credentials dans{' '}
+          <Link href="/dashboard/settings" style={{ color: '#D4921A', textDecoration: 'none' }}>
+            Paramètres
+          </Link>{' '}
+          et votre SIRET pour atteindre la conformité totale.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/components/ReformReadinessWidget.tsx
+++ b/src/app/components/ReformReadinessWidget.tsx
@@ -15,6 +15,12 @@ interface ReformReadiness {
   emit: ReadinessCheck;
 }
 
+const CHECK_LABELS: Record<string, string> = {
+  cproCredentials: 'Compte technique Chorus Pro',
+  pisteCredentials: 'Credentials PISTE API',
+  siretValidated: 'SIRET renseigné',
+};
+
 function urgencyColor(days: number, ready: boolean): string {
   if (ready) return '#16a34a';
   if (days < 90) return '#dc2626';
@@ -44,7 +50,9 @@ function CheckRow({ label, ok }: { label: string; ok: boolean }) {
 function DeadlineBlock({ label, data }: { label: string; data: ReadinessCheck }) {
   const color = urgencyColor(data.daysRemaining, data.ready);
   const bg = urgencyBg(data.daysRemaining, data.ready);
-  const deadline = new Date(data.deadlineDate).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+  // Parse ISO date parts directly to avoid local-timezone day shift for users west of UTC
+  const [year, month] = data.deadlineDate.split('-').map(Number);
+  const deadline = new Date(year, month - 1, 1).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
 
   return (
     <div style={{
@@ -98,14 +106,9 @@ function DeadlineBlock({ label, data }: { label: string; data: ReadinessCheck })
 
       {/* Checks */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-        {Object.entries(data.checks).map(([key, ok]) => {
-          const labels: Record<string, string> = {
-            cproCredentials: 'Compte technique Chorus Pro',
-            pisteCredentials: 'Credentials PISTE API',
-            siretValidated: 'SIRET renseigné',
-          };
-          return <CheckRow key={key} label={labels[key] ?? key} ok={ok} />;
-        })}
+        {Object.entries(data.checks).map(([key, ok]) => (
+          <CheckRow key={key} label={CHECK_LABELS[key] ?? key} ok={ok} />
+        ))}
       </div>
     </div>
   );
@@ -126,7 +129,11 @@ export default function ReformReadinessWidget() {
   if (!data) return null;
 
   const allReady = data.receive.ready && data.emit.ready;
-  const urgentIssue = !data.receive.ready && data.receive.daysRemaining < 180;
+  const minUnreadyDays = Math.min(
+    data.receive.ready ? Infinity : data.receive.daysRemaining,
+    data.emit.ready ? Infinity : data.emit.daysRemaining,
+  );
+  const urgentIssue = minUnreadyDays < 90;
 
   return (
     <div style={{

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
 import PWAInstallPrompt from "@/app/components/PWAInstallPrompt";
+import ReformReadinessWidget from "@/app/components/ReformReadinessWidget";
 
 interface UserInvoice {
   id: string;
@@ -148,6 +149,8 @@ export default function DashboardPage() {
       <div className="d-none d-lg-block mb-4">
         <PWAInstallPrompt />
       </div>
+
+      <ReformReadinessWidget />
 
       <div className="row g-3 mb-4">
         <div className="col-lg-3 col-md-6">


### PR DESCRIPTION
## Summary

- New `/api/reform-readiness` endpoint — checks CPRO credentials (receive) + PISTE credentials + SIRET validation (emit); returns days remaining to each deadline
- New `ReformReadinessWidget` client component — two side-by-side blocks, one per deadline, with ✅/❌ per check, countdown in days, urgency colouring (red <90d, amber <180d, green if ready)
- Widget placed on the main dashboard above the stats row — visible on every login

## What it checks

| Check | Deadline |
|---|---|
| `CPRO_TECH_LOGIN` + `CPRO_TECH_PASSWORD` set | Receive · Sep 2026 |
| `PISTE_CLIENT_ID` + `PISTE_CLIENT_SECRET` set | Emit · Sep 2027 |
| User SIRET validated in DB | Emit · Sep 2027 |

## Test plan

- [ ] Widget renders on `/dashboard` — empty/unconfigured state shows "Non configuré" with countdown
- [ ] API returns correct `ready` flags based on env vars and user SIRET
- [ ] "Configurer →" link routes to `/dashboard/settings`
- [ ] Widget is hidden (`return null`) while loading so it doesn't flash