### PR TITLE
feat: per-tenant Chorus Pro / PISTE credentials (Phase 1 multi-tenancy)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,12 @@ model User {
   rcsNumber           String?
   shareCapital        String?
   apeCode             String?
+  // Per-tenant Chorus Pro / PISTE credentials (passwords AES-256-GCM encrypted)
+  cproTechLogin       String?
+  cproTechPassword    String?
+  pisteClientId       String?
+  pisteClientSecret   String?
+  pisteEnv            String   @default("sandbox")
   accounts            Account[]
   sessions            Session[]
   clients               Client[]

--- a/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
+++ b/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { submitInvoiceToPpf, mapPpfStatus } from '@/lib/piste-api';
 import { buildFacturxXml } from '@/lib/facturx';
 import { logActivity } from '@/lib/activity-log';
+import { getUserPisteCredentials } from '@/app/api/settings/piste-credentials/route';
 
 // POST /api/invoices/[invoiceId]/submit-ppf
 // Deposits a Factur-X invoice to Chorus Pro via the PISTE API.
@@ -115,6 +116,9 @@ export async function POST(
     return NextResponse.json({ error: `Impossible de récupérer le PDF: ${err.message}` }, { status: 500 });
   }
 
+  // Resolve per-user credentials; fall back to platform env vars if not configured
+  const userCreds = await getUserPisteCredentials(session.user.id) ?? undefined;
+
   // Submit to PISTE
   const result = await submitInvoiceToPpf({
     invoiceNumber: invoice.invoiceNumber,
@@ -124,6 +128,7 @@ export async function POST(
     buyerSiret: buyerSiret ?? '',
     invoiceDate: invoice.invoiceDate.toISOString().split('T')[0],
     totalAmount: Number(invoice.totalAmount),
+    credentials: userCreds ?? undefined,
   });
 
   if (!result.success) {

--- a/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
+++ b/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
@@ -5,7 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { submitInvoiceToPpf, mapPpfStatus } from '@/lib/piste-api';
 import { buildFacturxXml } from '@/lib/facturx';
 import { logActivity } from '@/lib/activity-log';
-import { getUserPisteCredentials } from '@/app/api/settings/piste-credentials/route';
+import { getUserPisteCredentials } from '@/lib/user-piste-credentials';
 
 // POST /api/invoices/[invoiceId]/submit-ppf
 // Deposits a Factur-X invoice to Chorus Pro via the PISTE API.

--- a/src/app/api/settings/piste-credentials/route.ts
+++ b/src/app/api/settings/piste-credentials/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth-options';
 import { prisma } from '@/lib/prisma';
-import { encryptCredential, decryptCredential } from '@/lib/credential-crypto';
+import { encryptCredential } from '@/lib/credential-crypto';
 
 // GET — return whether credentials are configured (never returns plaintext secrets)
 export async function GET() {
@@ -72,25 +72,4 @@ export async function DELETE() {
   });
 
   return NextResponse.json({ ok: true });
-}
-
-// Helper exported for other server-side code: resolve decrypted user credentials
-export async function getUserPisteCredentials(userId: string) {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { cproTechLogin: true, cproTechPassword: true, pisteClientId: true, pisteClientSecret: true, pisteEnv: true },
-  });
-  if (!user?.pisteClientId || !user.cproTechLogin) return null;
-
-  try {
-    return {
-      pisteClientId: user.pisteClientId,
-      pisteClientSecret: user.pisteClientSecret ? decryptCredential(user.pisteClientSecret) : '',
-      cproTechLogin: user.cproTechLogin,
-      cproTechPassword: user.cproTechPassword ? decryptCredential(user.cproTechPassword) : '',
-      pisteEnv: (user.pisteEnv ?? 'sandbox') as 'sandbox' | 'production',
-    };
-  } catch {
-    return null;
-  }
 }

--- a/src/app/api/settings/piste-credentials/route.ts
+++ b/src/app/api/settings/piste-credentials/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+import { encryptCredential, decryptCredential } from '@/lib/credential-crypto';
+
+// GET — return whether credentials are configured (never returns plaintext secrets)
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return new NextResponse('Unauthorized', { status: 401 });
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { cproTechLogin: true, cproTechPassword: true, pisteClientId: true, pisteClientSecret: true, pisteEnv: true },
+  });
+
+  return NextResponse.json({
+    pisteEnv: user?.pisteEnv ?? 'sandbox',
+    pisteClientId: user?.pisteClientId ?? '',
+    pisteClientSecretSet: !!user?.pisteClientSecret,
+    cproTechLogin: user?.cproTechLogin ?? '',
+    cproTechPasswordSet: !!user?.cproTechPassword,
+  });
+}
+
+const SENSITIVE = ['pisteClientSecret', 'cproTechPassword'] as const;
+
+// PUT — save credentials (passwords encrypted at rest)
+export async function PUT(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return new NextResponse('Unauthorized', { status: 401 });
+
+  const body = await request.json() as {
+    pisteEnv?: string;
+    pisteClientId?: string;
+    pisteClientSecret?: string;
+    cproTechLogin?: string;
+    cproTechPassword?: string;
+  };
+
+  const data: Record<string, string> = {};
+
+  if (body.pisteEnv) data.pisteEnv = body.pisteEnv === 'production' ? 'production' : 'sandbox';
+  if (body.pisteClientId !== undefined) data.pisteClientId = body.pisteClientId;
+  if (body.cproTechLogin !== undefined) data.cproTechLogin = body.cproTechLogin;
+
+  // Encrypt secrets — only update if a non-empty value was sent
+  for (const field of SENSITIVE) {
+    const value = body[field];
+    if (value && value.trim()) {
+      try {
+        data[field] = encryptCredential(value.trim());
+      } catch {
+        return NextResponse.json({ error: 'Encryption not configured (CREDENTIAL_ENCRYPTION_KEY missing)' }, { status: 500 });
+      }
+    }
+  }
+
+  await prisma.user.update({ where: { id: session.user.id }, data });
+
+  return NextResponse.json({ ok: true });
+}
+
+// DELETE — clear all PISTE credentials for this user
+export async function DELETE() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return new NextResponse('Unauthorized', { status: 401 });
+
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { cproTechLogin: null, cproTechPassword: null, pisteClientId: null, pisteClientSecret: null, pisteEnv: 'sandbox' },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+// Helper exported for other server-side code: resolve decrypted user credentials
+export async function getUserPisteCredentials(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { cproTechLogin: true, cproTechPassword: true, pisteClientId: true, pisteClientSecret: true, pisteEnv: true },
+  });
+  if (!user?.pisteClientId || !user.cproTechLogin) return null;
+
+  try {
+    return {
+      pisteClientId: user.pisteClientId,
+      pisteClientSecret: user.pisteClientSecret ? decryptCredential(user.pisteClientSecret) : '',
+      cproTechLogin: user.cproTechLogin,
+      cproTechPassword: user.cproTechPassword ? decryptCredential(user.cproTechPassword) : '',
+      pisteEnv: (user.pisteEnv ?? 'sandbox') as 'sandbox' | 'production',
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/app/api/settings/test-piste/route.ts
+++ b/src/app/api/settings/test-piste/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { testPisteConnection } from '@/lib/piste-api';
+import { getUserPisteCredentials } from '@/app/api/settings/piste-credentials/route';
+import { decryptCredential } from '@/lib/credential-crypto';
+
+// POST — test PISTE connection using body credentials (in-flight) or saved DB credentials
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return new NextResponse('Unauthorized', { status: 401 });
+
+  const body = await request.json() as {
+    pisteEnv?: string;
+    pisteClientId?: string;
+    pisteClientSecret?: string;   // plaintext, in-flight (not yet saved)
+    cproTechLogin?: string;
+    cproTechPassword?: string;    // plaintext, in-flight
+    useSaved?: boolean;           // if true, use credentials from DB
+  };
+
+  let creds: { pisteClientId: string; pisteClientSecret: string; cproTechLogin: string; cproTechPassword: string; pisteEnv: 'sandbox' | 'production' } | null = null;
+
+  if (body.useSaved) {
+    creds = await getUserPisteCredentials(session.user.id);
+    if (!creds) {
+      return NextResponse.json({ ok: false, error: 'Aucun identifiant configuré — renseignez et sauvegardez d\'abord vos credentials.' });
+    }
+  } else {
+    if (!body.pisteClientId || !body.pisteClientSecret || !body.cproTechLogin || !body.cproTechPassword) {
+      return NextResponse.json({ ok: false, error: 'Tous les champs sont requis pour tester la connexion.' });
+    }
+    creds = {
+      pisteClientId: body.pisteClientId,
+      pisteClientSecret: body.pisteClientSecret,
+      cproTechLogin: body.cproTechLogin,
+      cproTechPassword: body.cproTechPassword,
+      pisteEnv: body.pisteEnv === 'production' ? 'production' : 'sandbox',
+    };
+  }
+
+  const result = await testPisteConnection(creds);
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/settings/test-piste/route.ts
+++ b/src/app/api/settings/test-piste/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth-options';
 import { testPisteConnection } from '@/lib/piste-api';
-import { getUserPisteCredentials } from '@/app/api/settings/piste-credentials/route';
+import { getUserPisteCredentials } from '@/lib/user-piste-credentials';
 import { decryptCredential } from '@/lib/credential-crypto';
 
 // POST — test PISTE connection using body credentials (in-flight) or saved DB credentials

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -134,38 +134,48 @@ function SettingsPageInner() {
     e.preventDefault();
     setPisteSaving(true);
     setPisteMessage(null);
-    const res = await fetch('/api/settings/piste-credentials', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(pisteForm),
-    });
-    if (res.ok) {
-      setPisteMessage({ type: 'success', text: 'Credentials sauvegardés.' });
-      await fetchPisteCredentials();
-      setPisteForm((f) => ({ ...f, pisteClientSecret: '', cproTechPassword: '' }));
-    } else {
-      const body = await res.json().catch(() => ({}));
-      setPisteMessage({ type: 'error', text: body.error ?? 'Erreur lors de la sauvegarde.' });
+    try {
+      const res = await fetch('/api/settings/piste-credentials', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(pisteForm),
+      });
+      if (res.ok) {
+        setPisteMessage({ type: 'success', text: 'Credentials sauvegardés.' });
+        await fetchPisteCredentials();
+        setPisteForm((f) => ({ ...f, pisteClientSecret: '', cproTechPassword: '' }));
+      } else {
+        const body = await res.json().catch(() => ({})) as { error?: string };
+        setPisteMessage({ type: 'error', text: body.error ?? 'Erreur lors de la sauvegarde.' });
+      }
+    } catch {
+      setPisteMessage({ type: 'error', text: 'Erreur réseau — vérifiez votre connexion.' });
+    } finally {
+      setPisteSaving(false);
     }
-    setPisteSaving(false);
   };
 
   const handlePisteTest = async () => {
     setPisteTesting(true);
     setPisteMessage({ type: 'info', text: 'Test en cours…' });
-    const body = pisteForm.pisteClientSecret || pisteForm.cproTechPassword
-      ? pisteForm
-      : { useSaved: true };
-    const res = await fetch('/api/settings/test-piste', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    const data = await res.json();
-    setPisteMessage(data.ok
-      ? { type: 'success', text: 'Connexion PISTE réussie — credentials valides.' }
-      : { type: 'error', text: data.error ?? 'Connexion échouée.' });
-    setPisteTesting(false);
+    try {
+      const body = pisteForm.pisteClientSecret || pisteForm.cproTechPassword
+        ? pisteForm
+        : { useSaved: true };
+      const res = await fetch('/api/settings/test-piste', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json().catch(() => ({ ok: false, error: 'Réponse invalide du serveur.' })) as { ok: boolean; error?: string };
+      setPisteMessage(data.ok
+        ? { type: 'success', text: 'Connexion PISTE réussie — credentials valides.' }
+        : { type: 'error', text: data.error ?? 'Connexion échouée.' });
+    } catch {
+      setPisteMessage({ type: 'error', text: 'Erreur réseau — vérifiez votre connexion.' });
+    } finally {
+      setPisteTesting(false);
+    }
   };
 
   const handleProfileSave = async (e: React.FormEvent) => {

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -38,13 +38,38 @@ function SettingsPageInner() {
   const [stripeConnecting, setStripeConnecting] = useState(false);
   const [siretLookup, setSiretLookup] = useState<{ loading: boolean; result: string | null; error: string | null }>({ loading: false, result: null, error: null });
 
+  // Chorus Pro / PISTE credentials
+  const [pisteForm, setPisteForm] = useState({
+    pisteEnv: 'sandbox',
+    pisteClientId: '',
+    pisteClientSecret: '',
+    cproTechLogin: '',
+    cproTechPassword: '',
+  });
+  const [pisteStatus, setPisteStatus] = useState({ pisteClientSecretSet: false, cproTechPasswordSet: false });
+  const [pisteSaving, setPisteSaving] = useState(false);
+  const [pisteTesting, setPisteTesting] = useState(false);
+  const [pisteMessage, setPisteMessage] = useState<{ type: 'success' | 'error' | 'info'; text: string } | null>(null);
+
   useEffect(() => {
     if (status === 'unauthenticated') {
       router.push('/auth/signin');
     } else if (status === 'authenticated') {
       fetchProfile();
+      fetchPisteCredentials();
     }
   }, [status, router]);
+
+  const fetchPisteCredentials = async () => {
+    try {
+      const res = await fetch('/api/settings/piste-credentials');
+      if (res.ok) {
+        const data = await res.json();
+        setPisteForm((f) => ({ ...f, pisteEnv: data.pisteEnv ?? 'sandbox', pisteClientId: data.pisteClientId ?? '', cproTechLogin: data.cproTechLogin ?? '' }));
+        setPisteStatus({ pisteClientSecretSet: data.pisteClientSecretSet, cproTechPasswordSet: data.cproTechPasswordSet });
+      }
+    } catch { /* ignore */ }
+  };
 
   const fetchProfile = async () => {
     try {
@@ -104,6 +129,44 @@ function SettingsPageInner() {
       setSiretLookup({ loading: false, result: null, error: 'Erreur de vérification SIRENE' });
     }
   }, [profile.siret]);
+
+  const handlePisteSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setPisteSaving(true);
+    setPisteMessage(null);
+    const res = await fetch('/api/settings/piste-credentials', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(pisteForm),
+    });
+    if (res.ok) {
+      setPisteMessage({ type: 'success', text: 'Credentials sauvegardés.' });
+      await fetchPisteCredentials();
+      setPisteForm((f) => ({ ...f, pisteClientSecret: '', cproTechPassword: '' }));
+    } else {
+      const body = await res.json().catch(() => ({}));
+      setPisteMessage({ type: 'error', text: body.error ?? 'Erreur lors de la sauvegarde.' });
+    }
+    setPisteSaving(false);
+  };
+
+  const handlePisteTest = async () => {
+    setPisteTesting(true);
+    setPisteMessage({ type: 'info', text: 'Test en cours…' });
+    const body = pisteForm.pisteClientSecret || pisteForm.cproTechPassword
+      ? pisteForm
+      : { useSaved: true };
+    const res = await fetch('/api/settings/test-piste', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    setPisteMessage(data.ok
+      ? { type: 'success', text: 'Connexion PISTE réussie — credentials valides.' }
+      : { type: 'error', text: data.error ?? 'Connexion échouée.' });
+    setPisteTesting(false);
+  };
 
   const handleProfileSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -276,6 +339,128 @@ function SettingsPageInner() {
                   {profileMessage?.type === 'success' && (
                     <span className="text-success small"><i className="bi bi-check-circle me-1"></i>{profileMessage.text}</span>
                   )}
+                </div>
+              </form>
+            </div>
+          </div>
+
+          {/* ── Chorus Pro / PISTE ───────────────────────────── */}
+          <div className="card mb-4 shadow-sm">
+            <div className="card-header bg-white">
+              <h5 className="mb-0 fw-semibold">
+                <i className="bi bi-shield-lock me-2 text-primary"></i>
+                Chorus Pro / PISTE
+              </h5>
+              <small className="text-muted">
+                Credentials requis pour soumettre et recevoir des factures via le Portail Public de Facturation.
+              </small>
+            </div>
+            <div className="card-body">
+              {pisteMessage && (
+                <div className={`alert alert-${pisteMessage.type === 'success' ? 'success' : pisteMessage.type === 'info' ? 'info' : 'danger'} alert-dismissible`}>
+                  {pisteMessage.type === 'success' && <i className="bi bi-check-circle me-2" />}
+                  {pisteMessage.type === 'error' && <i className="bi bi-x-circle me-2" />}
+                  {pisteMessage.text}
+                  <button type="button" className="btn-close" onClick={() => setPisteMessage(null)} />
+                </div>
+              )}
+
+              <form onSubmit={handlePisteSave}>
+                <div className="row g-3">
+                  {/* Environment */}
+                  <div className="col-12">
+                    <label className="form-label fw-medium">Environnement</label>
+                    <select
+                      className="form-select"
+                      value={pisteForm.pisteEnv}
+                      onChange={(e) => setPisteForm((f) => ({ ...f, pisteEnv: e.target.value }))}
+                    >
+                      <option value="sandbox">Sandbox (tests)</option>
+                      <option value="production">Production</option>
+                    </select>
+                    <small className="text-muted">Utilisez sandbox pour les tests, production pour les vraies factures.</small>
+                  </div>
+
+                  {/* PISTE OAuth2 */}
+                  <div className="col-12">
+                    <div className="fw-medium text-muted mb-2" style={{ fontSize: '0.8125rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                      Credentials PISTE (OAuth2)
+                    </div>
+                  </div>
+                  <div className="col-md-6">
+                    <label className="form-label fw-medium">Client ID</label>
+                    <input
+                      className="form-control font-monospace"
+                      placeholder="votre-client-id"
+                      value={pisteForm.pisteClientId}
+                      onChange={(e) => setPisteForm((f) => ({ ...f, pisteClientId: e.target.value }))}
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <label className="form-label fw-medium">
+                      Client Secret
+                      {pisteStatus.pisteClientSecretSet && <span className="badge bg-success ms-2 fw-normal">Configuré</span>}
+                    </label>
+                    <input
+                      type="password"
+                      className="form-control font-monospace"
+                      placeholder={pisteStatus.pisteClientSecretSet ? '••••••••• (laisser vide pour conserver)' : 'votre-client-secret'}
+                      value={pisteForm.pisteClientSecret}
+                      onChange={(e) => setPisteForm((f) => ({ ...f, pisteClientSecret: e.target.value }))}
+                      autoComplete="new-password"
+                    />
+                  </div>
+
+                  {/* Chorus Pro compte technique */}
+                  <div className="col-12">
+                    <div className="fw-medium text-muted mb-2 mt-1" style={{ fontSize: '0.8125rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                      Compte Technique Chorus Pro
+                    </div>
+                  </div>
+                  <div className="col-md-6">
+                    <label className="form-label fw-medium">Login</label>
+                    <input
+                      className="form-control"
+                      placeholder="login-compte-technique"
+                      value={pisteForm.cproTechLogin}
+                      onChange={(e) => setPisteForm((f) => ({ ...f, cproTechLogin: e.target.value }))}
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <label className="form-label fw-medium">
+                      Mot de passe
+                      {pisteStatus.cproTechPasswordSet && <span className="badge bg-success ms-2 fw-normal">Configuré</span>}
+                    </label>
+                    <input
+                      type="password"
+                      className="form-control"
+                      placeholder={pisteStatus.cproTechPasswordSet ? '••••••••• (laisser vide pour conserver)' : 'mot-de-passe'}
+                      value={pisteForm.cproTechPassword}
+                      onChange={(e) => setPisteForm((f) => ({ ...f, cproTechPassword: e.target.value }))}
+                      autoComplete="new-password"
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-4 d-flex flex-wrap align-items-center gap-2">
+                  <button type="submit" className="btn btn-primary px-4" disabled={pisteSaving}>
+                    {pisteSaving
+                      ? <><span className="spinner-border spinner-border-sm me-2" />Enregistrement…</>
+                      : <><i className="bi bi-check-lg me-2" />Enregistrer</>}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                    onClick={handlePisteTest}
+                    disabled={pisteTesting}
+                  >
+                    {pisteTesting
+                      ? <><span className="spinner-border spinner-border-sm me-2" />Test…</>
+                      : <><i className="bi bi-wifi me-2" />Tester la connexion</>}
+                  </button>
+                  <small className="text-muted">
+                    <i className="bi bi-lock me-1" />Les mots de passe sont chiffrés AES-256 avant stockage.
+                  </small>
                 </div>
               </form>
             </div>

--- a/src/lib/credential-crypto.ts
+++ b/src/lib/credential-crypto.ts
@@ -1,0 +1,38 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+// CREDENTIAL_ENCRYPTION_KEY must be a 64-char hex string (32 bytes).
+// Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+function getKey(): Buffer {
+  const hex = process.env.CREDENTIAL_ENCRYPTION_KEY;
+  if (!hex || hex.length !== 64) {
+    throw new Error('CREDENTIAL_ENCRYPTION_KEY must be a 64-character hex string');
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+export function encryptCredential(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${encrypted.toString('hex')}:${tag.toString('hex')}`;
+}
+
+export function decryptCredential(ciphertext: string): string {
+  const key = getKey();
+  const parts = ciphertext.split(':');
+  if (parts.length !== 3) throw new Error('Invalid ciphertext format');
+  const [ivHex, dataHex, tagHex] = parts;
+  const iv = Buffer.from(ivHex, 'hex');
+  const data = Buffer.from(dataHex, 'hex');
+  const tag = Buffer.from(tagHex, 'hex');
+  // authTagLength: 16 enforces full 128-bit tag — prevents GCM tag-truncation forgery
+  const decipher = createDecipheriv('aes-256-gcm', key, iv, { authTagLength: 16 });
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(data), decipher.final()]).toString('utf8');
+}
+
+export function isEncrypted(value: string): boolean {
+  return value.split(':').length === 3;
+}

--- a/src/lib/credential-crypto.ts
+++ b/src/lib/credential-crypto.ts
@@ -4,10 +4,14 @@ import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 // Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 function getKey(): Buffer {
   const hex = process.env.CREDENTIAL_ENCRYPTION_KEY;
-  if (!hex || hex.length !== 64) {
+  if (!hex || !/^[0-9a-fA-F]{64}$/.test(hex)) {
     throw new Error('CREDENTIAL_ENCRYPTION_KEY must be a 64-character hex string');
   }
-  return Buffer.from(hex, 'hex');
+  const key = Buffer.from(hex, 'hex');
+  if (key.length !== 32) {
+    throw new Error('CREDENTIAL_ENCRYPTION_KEY must decode to exactly 32 bytes');
+  }
+  return key;
 }
 
 export function encryptCredential(plaintext: string): string {

--- a/src/lib/piste-api.ts
+++ b/src/lib/piste-api.ts
@@ -21,6 +21,12 @@ export interface PisteCredentials {
   pisteEnv: 'sandbox' | 'production';
 }
 
+const VALID_ENVS = new Set(['sandbox', 'production']);
+
+function normalizePisteEnv(value: string | undefined): 'sandbox' | 'production' {
+  return value && VALID_ENVS.has(value) ? (value as 'sandbox' | 'production') : 'sandbox';
+}
+
 function getPlatformCredentials(): PisteCredentials | null {
   const pisteClientId = process.env.PISTE_CLIENT_ID;
   const pisteClientSecret = process.env.PISTE_CLIENT_SECRET;
@@ -34,7 +40,7 @@ function getPlatformCredentials(): PisteCredentials | null {
     pisteClientSecret,
     cproTechLogin,
     cproTechPassword,
-    pisteEnv: (process.env.PISTE_ENV as 'sandbox' | 'production') ?? 'sandbox',
+    pisteEnv: normalizePisteEnv(process.env.PISTE_ENV),
   };
 }
 
@@ -59,12 +65,25 @@ function getAuthUrl(env: string) {
     : 'https://sandbox-oauth.piste.gouv.fr/api/oauth/token';
 }
 
-// ─── Token cache keyed per pisteClientId (survives warm lambda invocations) ───
+// ─── Token cache keyed by "env:clientId" to prevent cross-env token reuse ────
 
 const tokenCache = new Map<string, { value: string; expiresAt: number }>();
 
+function tokenCacheKey(creds: PisteCredentials) {
+  return `${creds.pisteEnv}:${creds.pisteClientId}`;
+}
+
+function evictExpiredTokens() {
+  const now = Date.now();
+  for (const [key, entry] of tokenCache) {
+    if (now >= entry.expiresAt) tokenCache.delete(key);
+  }
+}
+
 async function getAccessToken(creds: PisteCredentials): Promise<string> {
-  const cached = tokenCache.get(creds.pisteClientId);
+  evictExpiredTokens();
+  const cacheKey = tokenCacheKey(creds);
+  const cached = tokenCache.get(cacheKey);
   if (cached && Date.now() < cached.expiresAt - 30_000) return cached.value;
 
   const res = await fetch(getAuthUrl(creds.pisteEnv), {
@@ -85,7 +104,7 @@ async function getAccessToken(creds: PisteCredentials): Promise<string> {
 
   const json = await res.json();
   const entry = { value: json.access_token, expiresAt: Date.now() + json.expires_in * 1000 };
-  tokenCache.set(creds.pisteClientId, entry);
+  tokenCache.set(cacheKey, entry);
   return entry.value;
 }
 
@@ -357,4 +376,4 @@ export async function testPisteConnection(creds: Partial<PisteCredentials>): Pro
 
 export { getPlatformCredentials };
 // Legacy export kept for reform-readiness check
-export const PISTE_ENV = process.env.PISTE_ENV ?? 'sandbox';
+export const PISTE_ENV = normalizePisteEnv(process.env.PISTE_ENV);

--- a/src/lib/piste-api.ts
+++ b/src/lib/piste-api.ts
@@ -2,10 +2,10 @@
  * PISTE API client — Portail de l'Impôt, de la Statistique et de l'Échange
  * OAuth2 client_credentials + Chorus Pro compte technique for PPF invoice submission.
  *
- * Sandbox:    https://sandbox-api.piste.gouv.fr
- * Production: https://api.piste.gouv.fr
+ * Supports both platform-level env var credentials (OD mode) and per-tenant credentials
+ * stored encrypted in the DB. Per-tenant credentials take precedence when provided.
  *
- * Required env vars:
+ * Required env vars (platform / OD fallback):
  *   PISTE_CLIENT_ID        — OAuth2 client ID
  *   PISTE_CLIENT_SECRET    — OAuth2 client secret
  *   PISTE_ENV              — "sandbox" | "production"  (default: "sandbox")
@@ -13,39 +13,67 @@
  *   CPRO_TECH_PASSWORD     — Chorus Pro compte technique password
  */
 
-const ENV = process.env.PISTE_ENV ?? 'sandbox';
+export interface PisteCredentials {
+  pisteClientId: string;
+  pisteClientSecret: string;
+  cproTechLogin: string;
+  cproTechPassword: string;
+  pisteEnv: 'sandbox' | 'production';
+}
 
-const PISTE_BASE = ENV === 'production'
-  ? 'https://api.piste.gouv.fr'
-  : 'https://sandbox-api.piste.gouv.fr';
-
-const AUTH_URL = ENV === 'production'
-  ? 'https://oauth.piste.gouv.fr/api/oauth/token'
-  : 'https://sandbox-oauth.piste.gouv.fr/api/oauth/token';
-
-// ─── Token cache (module-level, survives warm lambda invocations) ─────────────
-
-let cachedToken: { value: string; expiresAt: number } | null = null;
-
-async function getAccessToken(): Promise<string> {
-  if (cachedToken && Date.now() < cachedToken.expiresAt - 30_000) {
-    return cachedToken.value;
+function getPlatformCredentials(): PisteCredentials | null {
+  const pisteClientId = process.env.PISTE_CLIENT_ID;
+  const pisteClientSecret = process.env.PISTE_CLIENT_SECRET;
+  const cproTechLogin = process.env.CPRO_TECH_LOGIN;
+  const cproTechPassword = process.env.CPRO_TECH_PASSWORD;
+  if (!pisteClientId || !pisteClientSecret || !cproTechLogin || !cproTechPassword) {
+    return null;
   }
+  return {
+    pisteClientId,
+    pisteClientSecret,
+    cproTechLogin,
+    cproTechPassword,
+    pisteEnv: (process.env.PISTE_ENV as 'sandbox' | 'production') ?? 'sandbox',
+  };
+}
 
-  const clientId = process.env.PISTE_CLIENT_ID;
-  const clientSecret = process.env.PISTE_CLIENT_SECRET;
-
-  if (!clientId || !clientSecret) {
-    throw new Error('PISTE_CLIENT_ID and PISTE_CLIENT_SECRET must be set');
+function resolveCredentials(override?: Partial<PisteCredentials>): PisteCredentials {
+  const platform = getPlatformCredentials();
+  const merged = { ...platform, ...override } as Partial<PisteCredentials>;
+  if (!merged.pisteClientId || !merged.pisteClientSecret || !merged.cproTechLogin || !merged.cproTechPassword) {
+    throw new Error('PISTE credentials not configured. Set env vars or configure credentials in Settings.');
   }
+  return merged as PisteCredentials;
+}
 
-  const res = await fetch(AUTH_URL, {
+function getPisteBase(env: string) {
+  return env === 'production'
+    ? 'https://api.piste.gouv.fr'
+    : 'https://sandbox-api.piste.gouv.fr';
+}
+
+function getAuthUrl(env: string) {
+  return env === 'production'
+    ? 'https://oauth.piste.gouv.fr/api/oauth/token'
+    : 'https://sandbox-oauth.piste.gouv.fr/api/oauth/token';
+}
+
+// ─── Token cache keyed per pisteClientId (survives warm lambda invocations) ───
+
+const tokenCache = new Map<string, { value: string; expiresAt: number }>();
+
+async function getAccessToken(creds: PisteCredentials): Promise<string> {
+  const cached = tokenCache.get(creds.pisteClientId);
+  if (cached && Date.now() < cached.expiresAt - 30_000) return cached.value;
+
+  const res = await fetch(getAuthUrl(creds.pisteEnv), {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       grant_type: 'client_credentials',
-      client_id: clientId,
-      client_secret: clientSecret,
+      client_id: creds.pisteClientId,
+      client_secret: creds.pisteClientSecret,
       scope: 'openid',
     }),
   });
@@ -56,24 +84,13 @@ async function getAccessToken(): Promise<string> {
   }
 
   const json = await res.json();
-  cachedToken = {
-    value: json.access_token,
-    expiresAt: Date.now() + json.expires_in * 1000,
-  };
-
-  return cachedToken.value;
+  const entry = { value: json.access_token, expiresAt: Date.now() + json.expires_in * 1000 };
+  tokenCache.set(creds.pisteClientId, entry);
+  return entry.value;
 }
 
-// Chorus Pro requires login:password base64-encoded in cpro-account header
-function getCproAccountHeader(): string {
-  const login = process.env.CPRO_TECH_LOGIN;
-  const password = process.env.CPRO_TECH_PASSWORD;
-
-  if (!login || !password) {
-    throw new Error('CPRO_TECH_LOGIN and CPRO_TECH_PASSWORD must be set');
-  }
-
-  return Buffer.from(`${login}:${password}`).toString('base64');
+function getCproAccountHeader(creds: PisteCredentials): string {
+  return Buffer.from(`${creds.cproTechLogin}:${creds.cproTechPassword}`).toString('base64');
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -104,22 +121,22 @@ export interface PpfStatusResult {
 }
 
 // ─── Submit invoice to PPF via deposerFluxFacture ────────────────────────────
-// API accepts JSON with base64-encoded file content + syntaxeFlux field.
-// For Factur-X PDF/A-3: syntaxeFlux = "IN_DP_E2_CII_FACTURX", extension .pdf
-// For pure CII XML:     syntaxeFlux = "IN_DP_E1_CII_16B",      extension .xml
 
 export async function submitInvoiceToPpf(params: {
   invoiceNumber: string;
-  facturxPdfBuffer?: Buffer;   // PDF/A-3 Factur-X (preferred)
-  facturxXml: string;          // CII XML (fallback when no PDF)
+  facturxPdfBuffer?: Buffer;
+  facturxXml: string;
   sellerSiret: string;
   buyerSiret: string;
-  invoiceDate: string; // YYYY-MM-DD
+  invoiceDate: string;
   totalAmount: number;
+  credentials?: Partial<PisteCredentials>;
 }): Promise<PpfSubmitResult> {
   try {
-    const token = await getAccessToken();
-    const cproAccount = getCproAccountHeader();
+    const creds = resolveCredentials(params.credentials);
+    const token = await getAccessToken(creds);
+    const cproAccount = getCproAccountHeader(creds);
+    const PISTE_BASE = getPisteBase(creds.pisteEnv);
 
     let fichierFlux: string;
     let nomFichier: string;
@@ -168,10 +185,15 @@ export async function submitInvoiceToPpf(params: {
 
 // ─── Poll invoice lifecycle status from PPF ───────────────────────────────────
 
-export async function getPpfInvoiceStatus(trackingId: string): Promise<PpfStatusResult> {
+export async function getPpfInvoiceStatus(
+  trackingId: string,
+  credentials?: Partial<PisteCredentials>,
+): Promise<PpfStatusResult> {
   try {
-    const token = await getAccessToken();
-    const cproAccount = getCproAccountHeader();
+    const creds = resolveCredentials(credentials);
+    const token = await getAccessToken(creds);
+    const cproAccount = getCproAccountHeader(creds);
+    const PISTE_BASE = getPisteBase(creds.pisteEnv);
 
     const res = await fetch(`${PISTE_BASE}/cpro/factures/v1/consulter/historique`, {
       method: 'POST',
@@ -193,12 +215,10 @@ export async function getPpfInvoiceStatus(trackingId: string): Promise<PpfStatus
       };
     }
 
-    const statut = (json as any)?.statutCourant as string | undefined;
-
     return {
       success: true,
       trackingId,
-      status: statut as PpfLifecycleStatus | undefined,
+      status: (json as any)?.statutCourant as PpfLifecycleStatus | undefined,
       rejectionReason: (json as any)?.commentaireEtatCourant,
     };
   } catch (err: any) {
@@ -231,7 +251,7 @@ export interface ReceivedInvoiceEntry {
   buyerSiret: string | null;
   totalAmountTTC: number;
   ppfStatus: string;
-  depositedAt: string | null; // ISO string
+  depositedAt: string | null;
 }
 
 export interface FetchReceivedInvoicesResult {
@@ -242,13 +262,16 @@ export interface FetchReceivedInvoicesResult {
 }
 
 export async function fetchReceivedInvoicesFromPpf(opts: {
-  fromDate: string; // YYYY-MM-DD
-  toDate: string;   // YYYY-MM-DD
+  fromDate: string;
+  toDate: string;
   page?: number;
+  credentials?: Partial<PisteCredentials>;
 }): Promise<FetchReceivedInvoicesResult> {
   try {
-    const token = await getAccessToken();
-    const cproAccount = getCproAccountHeader();
+    const creds = resolveCredentials(opts.credentials);
+    const token = await getAccessToken(creds);
+    const cproAccount = getCproAccountHeader(creds);
+    const PISTE_BASE = getPisteBase(creds.pisteEnv);
 
     const res = await fetch(`${PISTE_BASE}/cpro/factures/v1/rechercher/destinataire`, {
       method: 'POST',
@@ -291,10 +314,15 @@ export async function fetchReceivedInvoicesFromPpf(opts: {
 
 // ─── Download raw XML for a received invoice ──────────────────────────────────
 
-export async function downloadReceivedInvoiceXml(cppId: string): Promise<string | null> {
+export async function downloadReceivedInvoiceXml(
+  cppId: string,
+  credentials?: Partial<PisteCredentials>,
+): Promise<string | null> {
   try {
-    const token = await getAccessToken();
-    const cproAccount = getCproAccountHeader();
+    const creds = resolveCredentials(credentials);
+    const token = await getAccessToken(creds);
+    const cproAccount = getCproAccountHeader(creds);
+    const PISTE_BASE = getPisteBase(creds.pisteEnv);
 
     const res = await fetch(`${PISTE_BASE}/cpro/factures/v1/telecharger`, {
       method: 'POST',
@@ -315,4 +343,18 @@ export async function downloadReceivedInvoiceXml(cppId: string): Promise<string 
   }
 }
 
-export { ENV as PISTE_ENV };
+// ─── Lightweight token test — validates PISTE credentials without side effects ─
+
+export async function testPisteConnection(creds: Partial<PisteCredentials>): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const resolved = resolveCredentials(creds);
+    await getAccessToken(resolved);
+    return { ok: true };
+  } catch (err: any) {
+    return { ok: false, error: err?.message ?? 'Connection test failed' };
+  }
+}
+
+export { getPlatformCredentials };
+// Legacy export kept for reform-readiness check
+export const PISTE_ENV = process.env.PISTE_ENV ?? 'sandbox';

--- a/src/lib/user-piste-credentials.ts
+++ b/src/lib/user-piste-credentials.ts
@@ -1,0 +1,25 @@
+import { prisma } from '@/lib/prisma';
+import { decryptCredential } from '@/lib/credential-crypto';
+import type { PisteCredentials } from '@/lib/piste-api';
+
+/** Resolve and decrypt per-user PISTE credentials from the DB. Returns null if not configured. */
+export async function getUserPisteCredentials(userId: string): Promise<PisteCredentials | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { cproTechLogin: true, cproTechPassword: true, pisteClientId: true, pisteClientSecret: true, pisteEnv: true },
+  });
+
+  if (!user?.pisteClientId || !user.cproTechLogin) return null;
+
+  try {
+    return {
+      pisteClientId: user.pisteClientId,
+      pisteClientSecret: user.pisteClientSecret ? decryptCredential(user.pisteClientSecret) : '',
+      cproTechLogin: user.cproTechLogin,
+      cproTechPassword: user.cproTechPassword ? decryptCredential(user.cproTechPassword) : '',
+      pisteEnv: (user.pisteEnv ?? 'sandbox') as 'sandbox' | 'production',
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/user-piste-credentials.ts
+++ b/src/lib/user-piste-credentials.ts
@@ -14,11 +14,11 @@ export async function getUserPisteCredentials(userId: string): Promise<PisteCred
   try {
     return {
       pisteClientId: user.pisteClientId,
-      pisteClientSecret: user.pisteClientSecret ? decryptCredential(user.pisteClientSecret) : '',
       cproTechLogin: user.cproTechLogin,
-      cproTechPassword: user.cproTechPassword ? decryptCredential(user.cproTechPassword) : '',
       pisteEnv: (user.pisteEnv ?? 'sandbox') as 'sandbox' | 'production',
-    };
+      ...(user.pisteClientSecret ? { pisteClientSecret: decryptCredential(user.pisteClientSecret) } : {}),
+      ...(user.cproTechPassword ? { cproTechPassword: decryptCredential(user.cproTechPassword) } : {}),
+    } as PisteCredentials;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Enables any client to configure their own Chorus Pro / PISTE credentials — the biggest blocker to signing a first paying customer.

### What changed

- **Schema**: 5 new fields on `User` — `cproTechLogin`, `cproTechPassword`, `pisteClientId`, `pisteClientSecret`, `pisteEnv`
- **`src/lib/credential-crypto.ts`**: AES-256-GCM encrypt/decrypt (256-bit key, explicit 128-bit auth tag — Semgrep-verified). Requires `CREDENTIAL_ENCRYPTION_KEY` env var (64-char hex).
- **`src/lib/piste-api.ts`**: Fully refactored. All 5 functions accept optional `PisteCredentials` override; fall back to platform env vars. Token cache is now per `pisteClientId` (Map, not module singleton).
- **`GET/PUT/DELETE /api/settings/piste-credentials`**: Load masked status, save encrypted secrets, clear credentials.
- **`POST /api/settings/test-piste`**: Validates credentials with a live PISTE token fetch. Accepts in-flight fields (before save) or `useSaved: true`.
- **Settings page**: New "Chorus Pro / PISTE" card with environment selector, credential fields (secrets never echoed back), save + "Tester la connexion" button.
- **`submit-ppf` route**: Looks up user credentials before calling PISTE; falls back to platform OD credentials.

### New env var required

```
CREDENTIAL_ENCRYPTION_KEY=<64-char hex>
# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
```

## Test plan

- [ ] Add `CREDENTIAL_ENCRYPTION_KEY` to Vercel env vars
- [ ] Run `nvm use 20 && npx prisma db push` to apply schema
- [ ] Settings page → Chorus Pro / PISTE section renders with environment selector
- [ ] Enter sandbox credentials → Save → "Configuré" badge appears on secret fields
- [ ] "Tester la connexion" → success/error message returned
- [ ] Submit an invoice → uses user credentials (check server logs for which clientId was used)
- [ ] User with no credentials → submit-ppf falls back to platform env vars