### PR TITLE
fix: add security-events write permission to Trivy SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Added `security-events: write` permission to the `security-scan` job in `ci.yml`
- Root cause: `github/codeql-action/upload-sarif` requires this permission to post SARIF results to GitHub Code Scanning — without it the upload step fails with a 403
- The `notify` job failure was a cascade from `security-scan` failing

## Test plan

- [ ] CI run completes with `security-scan` green
- [ ] `notify` job passes (no cascade failure)