### PR TITLE
feat: Stripe subscription billing (Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ Path aliases: `@/` → `src/`, `@/domains/*` → `src/domains/*`, `@/types/*` �
 | `CPRO_TECH_LOGIN` / `CPRO_TECH_PASSWORD` | Chorus Pro compte technique for `cpro-account` header |
 | `PISTE_WEBHOOK_SECRET` | Shared secret for `/api/webhooks/ppf` |
 | `SIRENE_API_KEY` | INSEE SIRENE v3 API key for SIRET validation |
+| `STRIPE_PRO_PRICE_ID` | Stripe Price ID for the Pro monthly/yearly plan |
+| `STRIPE_PLATFORM_WEBHOOK_SECRET` | Webhook secret for `/api/webhooks/stripe-subscriptions` |
 
 ## Branch Strategy
 - `main` → production (auto-deploy Vercel project `splitfact-6xo8`)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,12 @@ model User {
   rcsNumber           String?
   shareCapital        String?
   apeCode             String?
+  // Platform subscription (Stripe Subscriptions — separate from Stripe Connect)
+  stripePlatformCustomerId  String?   @unique
+  subscriptionId            String?   @unique
+  subscriptionStatus        String    @default("free")  // free | trialing | active | past_due | canceled
+  planId                    String    @default("free")  // free | pro
+  subscriptionPeriodEnd     DateTime?
   // Per-tenant Chorus Pro / PISTE credentials (passwords AES-256-GCM encrypted)
   cproTechLogin       String?
   cproTechPassword    String?

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -4,9 +4,8 @@ import Stripe from 'stripe';
 import { authOptions } from '@/lib/auth-options';
 import { prisma } from '@/lib/prisma';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
-
 export async function POST(request: Request) {
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import Stripe from 'stripe';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const priceId = process.env.STRIPE_PRO_PRICE_ID;
+  if (!priceId) {
+    return NextResponse.json({ error: 'Billing not configured' }, { status: 503 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { email: true, stripePlatformCustomerId: true, subscriptionStatus: true },
+  });
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  // Already active — send to portal instead
+  if (user.subscriptionStatus === 'active' || user.subscriptionStatus === 'trialing') {
+    return NextResponse.json({ error: 'Already subscribed' }, { status: 400 });
+  }
+
+  const { successUrl, cancelUrl } = await request.json().catch(() => ({} as Record<string, string>));
+
+  let customerId = user.stripePlatformCustomerId;
+  if (!customerId) {
+    const customer = await stripe.customers.create({
+      email: user.email ?? undefined,
+      metadata: { userId: session.user.id },
+    });
+    customerId = customer.id;
+    await prisma.user.update({
+      where: { id: session.user.id },
+      data: { stripePlatformCustomerId: customerId },
+    });
+  }
+
+  const checkoutSession = await stripe.checkout.sessions.create({
+    customer: customerId,
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: successUrl ?? `${process.env.NEXTAUTH_URL}/dashboard/settings?billing=success`,
+    cancel_url: cancelUrl ?? `${process.env.NEXTAUTH_URL}/dashboard/settings?billing=cancelled`,
+    subscription_data: {
+      trial_period_days: 14,
+      metadata: { userId: session.user.id },
+    },
+  });
+
+  return NextResponse.json({ url: checkoutSession.url });
+}

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import Stripe from 'stripe';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
+
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { stripePlatformCustomerId: true },
+  });
+
+  if (!user?.stripePlatformCustomerId) {
+    return NextResponse.json({ error: 'No billing account found' }, { status: 404 });
+  }
+
+  const portalSession = await stripe.billingPortal.sessions.create({
+    customer: user.stripePlatformCustomerId,
+    return_url: `${process.env.NEXTAUTH_URL}/dashboard/settings`,
+  });
+
+  return NextResponse.json({ url: portalSession.url });
+}

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -4,9 +4,8 @@ import Stripe from 'stripe';
 import { authOptions } from '@/lib/auth-options';
 import { prisma } from '@/lib/prisma';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
-
 export async function POST() {
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/billing/subscription/route.ts
+++ b/src/app/api/billing/subscription/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      planId: true,
+      subscriptionStatus: true,
+      subscriptionPeriodEnd: true,
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    planId: user.planId,
+    subscriptionStatus: user.subscriptionStatus,
+    subscriptionPeriodEnd: user.subscriptionPeriodEnd,
+  });
+}

--- a/src/app/api/e-reporting/route.ts
+++ b/src/app/api/e-reporting/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth-options';
 import { prisma } from '@/lib/prisma';
 import { aggregateEReportingData, buildEReportingXml } from '@/lib/e-reporting/generate';
 import { submitInvoiceToPpf } from '@/lib/piste-api';
+import { isPro } from '@/lib/subscription';
 
 // GET /api/e-reporting?period=YYYY-MM  — fetch or generate period summary
 // POST /api/e-reporting                 — generate + optionally submit a period
@@ -33,6 +34,13 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  if (!(await isPro(session.user.id))) {
+    return NextResponse.json(
+      { error: 'E-reporting requires an InvoiceOps Pro plan.', upgrade: true },
+      { status: 403 }
+    );
+  }
 
   const body = await req.json().catch(() => ({}));
   const { period, submit = false } = body as { period: string; submit?: boolean };

--- a/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
+++ b/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
@@ -6,6 +6,7 @@ import { submitInvoiceToPpf, mapPpfStatus } from '@/lib/piste-api';
 import { buildFacturxXml } from '@/lib/facturx';
 import { logActivity } from '@/lib/activity-log';
 import { getUserPisteCredentials } from '@/lib/user-piste-credentials';
+import { isPro } from '@/lib/subscription';
 
 // POST /api/invoices/[invoiceId]/submit-ppf
 // Deposits a Factur-X invoice to Chorus Pro via the PISTE API.
@@ -17,6 +18,13 @@ export async function POST(
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!(await isPro(session.user.id))) {
+    return NextResponse.json(
+      { error: 'PPF submission requires an InvoiceOps Pro plan.', upgrade: true },
+      { status: 403 }
+    );
   }
 
   const { invoiceId } = await params;

--- a/src/app/api/webhooks/stripe-subscriptions/route.ts
+++ b/src/app/api/webhooks/stripe-subscriptions/route.ts
@@ -2,8 +2,6 @@ import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { prisma } from '@/lib/prisma';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
-
 function planFromPriceId(priceId: string | null | undefined): string {
   if (priceId && priceId === process.env.STRIPE_PRO_PRICE_ID) return 'pro';
   return 'free';
@@ -45,6 +43,7 @@ async function handleDeleted(sub: Stripe.Subscription) {
 }
 
 export async function POST(request: Request) {
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
   const sig = request.headers.get('stripe-signature');
   const webhookSecret = process.env.STRIPE_PLATFORM_WEBHOOK_SECRET;
 

--- a/src/app/api/webhooks/stripe-subscriptions/route.ts
+++ b/src/app/api/webhooks/stripe-subscriptions/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { prisma } from '@/lib/prisma';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
+
+function planFromPriceId(priceId: string | null | undefined): string {
+  if (priceId && priceId === process.env.STRIPE_PRO_PRICE_ID) return 'pro';
+  return 'free';
+}
+
+function periodEnd(sub: Stripe.Subscription): Date | null {
+  // cancel_at is set when subscription is scheduled to cancel at period end
+  const ts = sub.cancel_at ?? sub.billing_cycle_anchor;
+  return ts ? new Date(ts * 1000) : null;
+}
+
+async function syncSubscription(sub: Stripe.Subscription) {
+  const userId = sub.metadata?.userId;
+  if (!userId) return;
+
+  const priceId = sub.items.data[0]?.price?.id ?? null;
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      subscriptionId: sub.id,
+      subscriptionStatus: sub.status,
+      planId: planFromPriceId(priceId),
+      subscriptionPeriodEnd: periodEnd(sub),
+    },
+  });
+}
+
+async function handleDeleted(sub: Stripe.Subscription) {
+  const userId = sub.metadata?.userId;
+  if (!userId) return;
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      subscriptionStatus: 'canceled',
+      planId: 'free',
+      subscriptionPeriodEnd: periodEnd(sub),
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const sig = request.headers.get('stripe-signature');
+  const webhookSecret = process.env.STRIPE_PLATFORM_WEBHOOK_SECRET;
+
+  if (!sig || !webhookSecret) {
+    return NextResponse.json({ error: 'Missing signature' }, { status: 400 });
+  }
+
+  let event: Stripe.Event;
+  try {
+    const body = await request.text();
+    event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+  } catch {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  switch (event.type) {
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated':
+      await syncSubscription(event.data.object as Stripe.Subscription);
+      break;
+    case 'customer.subscription.deleted':
+      await handleDeleted(event.data.object as Stripe.Subscription);
+      break;
+    default:
+      break;
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -38,6 +38,9 @@ function SettingsPageInner() {
   const [stripeConnecting, setStripeConnecting] = useState(false);
   const [siretLookup, setSiretLookup] = useState<{ loading: boolean; result: string | null; error: string | null }>({ loading: false, result: null, error: null });
 
+  const [subscription, setSubscription] = useState<{ planId: string; subscriptionStatus: string; subscriptionPeriodEnd: string | null } | null>(null);
+  const [billingLoading, setBillingLoading] = useState(false);
+
   // Chorus Pro / PISTE credentials
   const [pisteForm, setPisteForm] = useState({
     pisteEnv: 'sandbox',
@@ -57,8 +60,44 @@ function SettingsPageInner() {
     } else if (status === 'authenticated') {
       fetchProfile();
       fetchPisteCredentials();
+      fetchSubscription();
     }
   }, [status, router]);
+
+  const fetchSubscription = async () => {
+    try {
+      const res = await fetch('/api/billing/subscription');
+      if (res.ok) setSubscription(await res.json());
+    } catch { /* ignore */ }
+  };
+
+  const handleUpgrade = async () => {
+    setBillingLoading(true);
+    try {
+      const res = await fetch('/api/billing/checkout', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) });
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Erreur');
+      const { url } = await res.json();
+      window.location.href = url;
+    } catch (err: any) {
+      setProfileMessage({ type: 'error', text: err.message });
+    } finally {
+      setBillingLoading(false);
+    }
+  };
+
+  const handleManageBilling = async () => {
+    setBillingLoading(true);
+    try {
+      const res = await fetch('/api/billing/portal', { method: 'POST' });
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Erreur');
+      const { url } = await res.json();
+      window.location.href = url;
+    } catch (err: any) {
+      setProfileMessage({ type: 'error', text: err.message });
+    } finally {
+      setBillingLoading(false);
+    }
+  };
 
   const fetchPisteCredentials = async () => {
     try {
@@ -517,6 +556,102 @@ function SettingsPageInner() {
                       ? <><i className="bi bi-arrow-repeat me-1"></i>Reconfigurer</>
                       : <><i className="bi bi-box-arrow-up-right me-1"></i>Connecter Stripe</>}
                 </button>
+              </div>
+            </div>
+          </div>
+
+          {/* ── Subscription & Billing ────────────────────────── */}
+          <div className="card mb-4 shadow-sm">
+            <div className="card-header bg-white">
+              <h5 className="mb-0 fw-semibold">
+                <i className="bi bi-credit-card me-2 text-primary"></i>
+                Abonnement InvoiceOps
+              </h5>
+              <small className="text-muted">PPF, e-reporting et fonctionnalités avancées requièrent le plan Pro.</small>
+            </div>
+            <div className="card-body">
+              {searchParams.get('billing') === 'success' && (
+                <div className="alert alert-success d-flex align-items-center gap-2 mb-3">
+                  <i className="bi bi-check-circle-fill"></i>
+                  Votre abonnement Pro est actif — bienvenue !
+                </div>
+              )}
+              {searchParams.get('billing') === 'cancelled' && (
+                <div className="alert alert-warning d-flex align-items-center gap-2 mb-3">
+                  <i className="bi bi-x-circle"></i>
+                  Paiement annulé. Vous pouvez réessayer à tout moment.
+                </div>
+              )}
+
+              {subscription ? (
+                <div className="d-flex align-items-center justify-content-between py-2">
+                  <div>
+                    <div className="fw-medium d-flex align-items-center gap-2">
+                      Plan actuel
+                      {subscription.planId === 'pro' ? (
+                        <span className="badge bg-primary"><i className="bi bi-lightning-fill me-1"></i>Pro</span>
+                      ) : (
+                        <span className="badge bg-secondary">Gratuit</span>
+                      )}
+                      {subscription.subscriptionStatus === 'trialing' && (
+                        <span className="badge bg-info text-dark">Période d'essai</span>
+                      )}
+                      {subscription.subscriptionStatus === 'past_due' && (
+                        <span className="badge bg-danger">Paiement en retard</span>
+                      )}
+                    </div>
+                    {subscription.subscriptionPeriodEnd && (
+                      <small className="text-muted">
+                        {subscription.subscriptionStatus === 'trialing'
+                          ? `Essai gratuit jusqu'au`
+                          : 'Renouvellement le'}{' '}
+                        {new Date(subscription.subscriptionPeriodEnd).toLocaleDateString('fr-FR')}
+                      </small>
+                    )}
+                  </div>
+                  {subscription.planId === 'pro' ? (
+                    <button className="btn btn-sm btn-outline-secondary" onClick={handleManageBilling} disabled={billingLoading}>
+                      {billingLoading ? <span className="spinner-border spinner-border-sm me-1" /> : <i className="bi bi-gear me-1"></i>}
+                      Gérer l'abonnement
+                    </button>
+                  ) : (
+                    <button className="btn btn-sm btn-primary" onClick={handleUpgrade} disabled={billingLoading}>
+                      {billingLoading ? <span className="spinner-border spinner-border-sm me-1" /> : <i className="bi bi-lightning-fill me-1"></i>}
+                      Passer au Pro — 14 jours gratuits
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <div className="d-flex align-items-center justify-content-between py-2">
+                  <div>
+                    <div className="fw-medium">Plan Gratuit</div>
+                    <small className="text-muted">Créez des factures et gérez vos clients sans limite.</small>
+                  </div>
+                  <button className="btn btn-sm btn-primary" onClick={handleUpgrade} disabled={billingLoading}>
+                    {billingLoading ? <span className="spinner-border spinner-border-sm me-1" /> : <i className="bi bi-lightning-fill me-1"></i>}
+                    Passer au Pro
+                  </button>
+                </div>
+              )}
+
+              <hr className="my-3" />
+              <div className="row g-2 text-center">
+                <div className="col-4">
+                  <small className="text-muted d-block">Factures illimitées</small>
+                  <i className="bi bi-check-circle-fill text-success"></i>
+                </div>
+                <div className="col-4">
+                  <small className="text-muted d-block">Dépôt PPF / Chorus Pro</small>
+                  {subscription?.planId === 'pro'
+                    ? <i className="bi bi-check-circle-fill text-success"></i>
+                    : <i className="bi bi-lock-fill text-warning"></i>}
+                </div>
+                <div className="col-4">
+                  <small className="text-muted d-block">E-reporting B2C</small>
+                  {subscription?.planId === 'pro'
+                    ? <i className="bi bi-check-circle-fill text-success"></i>
+                    : <i className="bi bi-lock-fill text-warning"></i>}
+                </div>
               </div>
             </div>
           </div>

--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -1,0 +1,17 @@
+import { prisma } from '@/lib/prisma';
+
+export type PlanId = 'free' | 'pro';
+
+export async function getUserPlan(userId: string): Promise<PlanId> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { planId: true, subscriptionStatus: true },
+  });
+  if (!user) return 'free';
+  const active = user.subscriptionStatus === 'active' || user.subscriptionStatus === 'trialing';
+  return active && user.planId === 'pro' ? 'pro' : 'free';
+}
+
+export async function isPro(userId: string): Promise<boolean> {
+  return (await getUserPlan(userId)) === 'pro';
+}


### PR DESCRIPTION
## Summary
- Adds subscription fields to `User` schema (platform customer ID, subscription ID, status, plan, period end) — applied via `prisma db push`
- `src/lib/subscription.ts` — `isPro(userId)` plan check utility (free vs pro)
- `/api/billing/subscription` (GET), `/api/billing/checkout` (POST — Stripe Checkout with 14-day trial), `/api/billing/portal` (POST — Stripe Customer Portal)
- `/api/webhooks/stripe-subscriptions` — syncs `customer.subscription.created/updated/deleted` events to DB
- Pro paywall on PPF submission (`/api/invoices/[invoiceId]/submit-ppf`) and e-reporting POST — returns HTTP 403 with `{ upgrade: true }` for free users
- Billing card in Settings page showing current plan badge, period end, and upgrade/manage CTA

## Setup required before going live
1. Create a Stripe Product + Price in the dashboard and set `STRIPE_PRO_PRICE_ID=price_xxx`
2. Register webhook endpoint `POST /api/webhooks/stripe-subscriptions` in Stripe → set `STRIPE_PLATFORM_WEBHOOK_SECRET=whsec_xxx`
3. Configure Stripe Customer Portal in the dashboard (allowed features: cancel, update payment)

## Test plan
- [ ] Free user → Settings page shows "Plan Gratuit" and "Passer au Pro" button
- [ ] Clicking upgrade redirects to Stripe Checkout with 14-day trial
- [ ] After sub created webhook fires → user `planId` = `pro`, `subscriptionStatus` = `trialing`
- [ ] Pro user can submit PPF and e-reporting; free user gets 403
- [ ] Settings shows "Gérer l'abonnement" for Pro users → redirects to portal
- [ ] Sub deleted webhook → planId reverts to `free`