### PR TITLE
feat: PISTE production validation (Phase 3)

### DIFF
--- a/src/app/api/cron/ppf-status-poll/route.ts
+++ b/src/app/api/cron/ppf-status-poll/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getPpfInvoiceStatus, mapPpfStatus, type PpfLifecycleStatus } from '@/lib/piste-api';
+import { getUserPisteCredentials } from '@/lib/user-piste-credentials';
+import { logActivity } from '@/lib/activity-log';
+
+// GET /api/cron/ppf-status-poll
+// Polls Chorus Pro for updated lifecycle status on in-flight invoices.
+// Runs daily — registered in vercel.json as a Vercel cron.
+// Only polls invoices in transient states (deposee, en_cours_de_routage, recue).
+const POLL_STATUSES = ['deposee', 'en_cours_de_routage', 'recue'];
+const TERMINAL_STATUSES = new Set(['approuvee', 'payee', 'rejetee', 'refusee']);
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('Authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const invoices = await prisma.invoice.findMany({
+    where: { ppfStatus: { in: POLL_STATUSES as any }, ppfTrackingId: { not: null } },
+    select: { id: true, userId: true, ppfTrackingId: true, ppfStatus: true },
+    take: 50,
+    orderBy: { ppfLastEventAt: 'asc' },
+  });
+
+  if (invoices.length === 0) return NextResponse.json({ polled: 0 });
+
+  let updated = 0;
+  let unchanged = 0;
+  let errored = 0;
+
+  for (const invoice of invoices) {
+    const userCreds = await getUserPisteCredentials(invoice.userId);
+    const result = await getPpfInvoiceStatus(invoice.ppfTrackingId!, userCreds ?? undefined);
+
+    if (!result.success || !result.status) {
+      errored++;
+      continue;
+    }
+
+    const newMapped = mapPpfStatus(result.status as PpfLifecycleStatus);
+
+    if (newMapped === invoice.ppfStatus) {
+      unchanged++;
+      continue;
+    }
+
+    await prisma.invoice.update({
+      where: { id: invoice.id },
+      data: {
+        ppfStatus: newMapped as any,
+        ppfLastEventAt: new Date(),
+        ppfError: result.rejectionReason ?? null,
+      },
+    });
+
+    await logActivity({
+      invoiceId: invoice.id,
+      userId: invoice.userId,
+      action: 'ppf_status_polled',
+      metadata: { from: invoice.ppfStatus, to: newMapped, trackingId: invoice.ppfTrackingId },
+    });
+
+    // Notify on terminal rejection
+    if (TERMINAL_STATUSES.has(newMapped) && (newMapped === 'rejetee' || newMapped === 'refusee')) {
+      await prisma.notification.create({
+        data: {
+          userId: invoice.userId,
+          type: 'GENERAL',
+          title: newMapped === 'rejetee' ? 'Facture rejetée par Chorus Pro' : 'Facture refusée par le client',
+          message: result.rejectionReason
+            ? `Motif : ${result.rejectionReason}`
+            : 'Consultez la facture pour voir le détail.',
+          actionUrl: `/dashboard/invoices/${invoice.id}`,
+          metadata: { trackingId: invoice.ppfTrackingId, ppfStatus: newMapped },
+        },
+      });
+    }
+
+    updated++;
+  }
+
+  return NextResponse.json({ polled: invoices.length, updated, unchanged, errored });
+}

--- a/src/app/api/invoices/[invoiceId]/ppf-preflight/route.ts
+++ b/src/app/api/invoices/[invoiceId]/ppf-preflight/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+import { testPisteConnection, getPlatformCredentials } from '@/lib/piste-api';
+import { getUserPisteCredentials } from '@/lib/user-piste-credentials';
+import { isPro } from '@/lib/subscription';
+
+export interface PpfPreflightResult {
+  ready: boolean;
+  blockers: string[];
+  warnings: string[];
+  pisteEnv: 'sandbox' | 'production' | null;
+}
+
+// GET /api/invoices/[invoiceId]/ppf-preflight
+// Validates all conditions for a successful PPF submission without submitting.
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ invoiceId: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { invoiceId } = await params;
+
+  const invoice = await prisma.invoice.findFirst({
+    where: { id: invoiceId, userId: session.user.id },
+    include: { client: true, items: true },
+  });
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
+  }
+
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+
+  // ── Plan check ────────────────────────────────────────────────────────────
+  const pro = await isPro(session.user.id);
+  if (!pro) {
+    blockers.push('Le dépôt PPF requiert le plan InvoiceOps Pro.');
+  }
+
+  // ── Workflow status ───────────────────────────────────────────────────────
+  if (invoice.workflowStatus !== 'issued') {
+    blockers.push(`La facture doit être en statut "issued" (actuel : ${invoice.workflowStatus}).`);
+  }
+
+  // ── Transaction type (B2C goes to e-reporting, not PPF) ───────────────────
+  if (invoice.transactionType === 'B2C') {
+    blockers.push('Les transactions B2C ne sont pas soumises au PPF — elles relèvent de l\'e-reporting.');
+  }
+
+  // ── Issuer SIRET ──────────────────────────────────────────────────────────
+  if (!invoice.issuerSiret || invoice.issuerSiret.length !== 14) {
+    blockers.push('Le SIRET de l\'émetteur est manquant ou invalide (14 chiffres requis).');
+  }
+
+  // ── Buyer SIRET (required for B2B/B2G) ───────────────────────────────────
+  const buyerSiret = invoice.clientSiret ?? invoice.client?.siret;
+  if (!buyerSiret || buyerSiret.length !== 14) {
+    if (invoice.transactionType === 'B2G') {
+      blockers.push('Le SIRET du destinataire est obligatoire pour les transactions B2G.');
+    } else {
+      warnings.push('Le SIRET du client est absent — la facture peut être rejetée par Chorus Pro.');
+    }
+  }
+
+  // ── Factur-X PDF ─────────────────────────────────────────────────────────
+  if (!invoice.facturxPdfUrl) {
+    blockers.push('Le PDF Factur-X n\'a pas encore été généré. Générez-le avant la soumission.');
+  }
+
+  if (invoice.facturxStatus === 'validation_failed') {
+    blockers.push('La validation du XML Factur-X a échoué. Corrigez les erreurs avant soumission.');
+  }
+
+  // ── Line items ───────────────────────────────────────────────────────────
+  if (!invoice.items || invoice.items.length === 0) {
+    blockers.push('La facture ne contient aucun article.');
+  }
+
+  // ── Already submitted & terminal ─────────────────────────────────────────
+  const terminalStatuses = ['approuvee', 'payee'];
+  if (terminalStatuses.includes(invoice.ppfStatus)) {
+    blockers.push(`La facture est déjà en statut terminal PPF : ${invoice.ppfStatus}.`);
+  }
+
+  // ── PISTE credentials ────────────────────────────────────────────────────
+  let pisteEnv: 'sandbox' | 'production' | null = null;
+  const userCreds = await getUserPisteCredentials(session.user.id);
+  const platformCreds = getPlatformCredentials();
+  const creds = userCreds ?? platformCreds;
+
+  if (!creds) {
+    blockers.push('Aucun credential PISTE configuré. Renseignez-les dans Paramètres → Chorus Pro.');
+  } else {
+    pisteEnv = creds.pisteEnv;
+    if (creds.pisteEnv === 'sandbox') {
+      warnings.push('Vous êtes en mode sandbox PISTE — la soumission n\'atteindra pas le PPF de production.');
+    }
+    // Test token acquisition without submitting
+    const connTest = await testPisteConnection(creds);
+    if (!connTest.ok) {
+      blockers.push(`Connexion PISTE échouée : ${connTest.error}. Vérifiez vos credentials dans Paramètres.`);
+    }
+  }
+
+  const result: PpfPreflightResult = {
+    ready: blockers.length === 0,
+    blockers,
+    warnings,
+    pisteEnv,
+  };
+
+  return NextResponse.json(result);
+}

--- a/src/app/dashboard/invoices/[invoiceId]/page.tsx
+++ b/src/app/dashboard/invoices/[invoiceId]/page.tsx
@@ -201,6 +201,8 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
   const [issuingInvoice, setIssuingInvoice] = useState(false);
   const [submittingPpf, setSubmittingPpf] = useState(false);
   const [ppfError, setPpfError] = useState<string | null>(null);
+  const [preflight, setPreflight] = useState<{ ready: boolean; blockers: string[]; warnings: string[]; pisteEnv: string | null } | null>(null);
+  const [preflightLoading, setPreflightLoading] = useState(false);
   const [sendingReminder, setSendingReminder] = useState(false);
   const [reminderSent, setReminderSent] = useState(false);
   const [stripeConnected, setStripeConnected] = useState(false);
@@ -341,12 +343,31 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
     try {
       const res = await fetch(`/api/invoices/${invoiceId}/submit-ppf`, { method: 'POST' });
       const payload = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(payload.error || 'Échec du dépôt sur Chorus Pro');
+      if (!res.ok) {
+        if (payload.upgrade) {
+          throw new Error('Le dépôt PPF requiert le plan InvoiceOps Pro. Passez au Pro dans Paramètres.');
+        }
+        throw new Error(payload.error || 'Échec du dépôt sur Chorus Pro');
+      }
       await loadInvoice();
     } catch (err: any) {
       setPpfError(err.message);
     } finally {
       setSubmittingPpf(false);
+    }
+  };
+
+  const handlePreflight = async () => {
+    setPreflightLoading(true);
+    setPreflight(null);
+    try {
+      const res = await fetch(`/api/invoices/${invoiceId}/ppf-preflight`);
+      const data = await res.json().catch(() => ({}));
+      setPreflight(data);
+    } catch {
+      setPreflight({ ready: false, blockers: ['Impossible de contacter le serveur.'], warnings: [], pisteEnv: null });
+    } finally {
+      setPreflightLoading(false);
     }
   };
 
@@ -719,12 +740,43 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
               <i className="bi bi-building me-2 text-primary"></i>
               Chorus Pro (PPF)
             </h2>
+
+            {/* Current status */}
             <div className="d-flex justify-content-between align-items-center mb-3">
               <span className="text-muted small">Statut</span>
               <span className={`badge ${ppfBadgeClass(invoice.ppfStatus)}`}>
                 {ppfStatusLabel(invoice.ppfStatus)}
               </span>
             </div>
+
+            {/* Lifecycle timeline for in-flight invoices */}
+            {invoice.ppfStatus && !['not_submitted', 'pending_retry'].includes(invoice.ppfStatus) && (
+              <div className="mb-3">
+                {(['deposee', 'en_cours_de_routage', 'recue', 'approuvee', 'payee'] as const).map((step, i) => {
+                  const steps = ['deposee', 'en_cours_de_routage', 'recue', 'approuvee', 'payee'];
+                  const currentIdx = steps.indexOf(invoice.ppfStatus ?? '');
+                  const isRejected = ['rejetee', 'refusee'].includes(invoice.ppfStatus ?? '');
+                  const isDone = currentIdx >= i;
+                  const labels: Record<string, string> = {
+                    deposee: 'Déposée', en_cours_de_routage: 'Routage', recue: 'Reçue',
+                    approuvee: 'Approuvée', payee: 'Payée',
+                  };
+                  return (
+                    <div key={step} className="d-flex align-items-center gap-2 mb-1">
+                      <i className={`bi ${isRejected && i === currentIdx ? 'bi-x-circle-fill text-danger' : isDone ? 'bi-check-circle-fill text-success' : 'bi-circle text-muted'}`} style={{ fontSize: '0.85rem' }}></i>
+                      <span className={`small ${isDone && !isRejected ? 'fw-semibold' : 'text-muted'}`}>{labels[step]}</span>
+                    </div>
+                  );
+                })}
+                {['rejetee', 'refusee'].includes(invoice.ppfStatus ?? '') && (
+                  <div className="d-flex align-items-center gap-2 mb-1">
+                    <i className="bi bi-x-circle-fill text-danger" style={{ fontSize: '0.85rem' }}></i>
+                    <span className="small fw-semibold text-danger">{ppfStatusLabel(invoice.ppfStatus)}</span>
+                  </div>
+                )}
+              </div>
+            )}
+
             {invoice.ppfTrackingId && (
               <div className="text-muted small mb-2">
                 Identifiant CPP : <code>{invoice.ppfTrackingId}</code>
@@ -752,17 +804,58 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
                 {ppfError}
               </div>
             )}
-            {invoice.workflowStatus === 'issued' && invoice.facturxPdfUrl &&
-              (!invoice.ppfStatus || ['not_submitted', 'pending_retry'].includes(invoice.ppfStatus)) && (
-              <button
-                className="btn btn-primary btn-sm w-100 mt-2"
-                onClick={handleSubmitPpf}
-                disabled={submittingPpf}
-              >
-                {submittingPpf
-                  ? <><span className="spinner-border spinner-border-sm me-1" />Dépôt en cours...</>
-                  : <><i className="bi bi-send me-1"></i>Déposer sur Chorus Pro</>}
-              </button>
+
+            {/* Preflight panel */}
+            {(!invoice.ppfStatus || ['not_submitted', 'pending_retry', 'rejetee', 'refusee'].includes(invoice.ppfStatus)) && (
+              <div className="mt-2">
+                <button
+                  className="btn btn-outline-secondary btn-sm w-100 mb-2"
+                  onClick={handlePreflight}
+                  disabled={preflightLoading}
+                >
+                  {preflightLoading
+                    ? <><span className="spinner-border spinner-border-sm me-1" />Vérification en cours...</>
+                    : <><i className="bi bi-shield-check me-1"></i>Vérifier les prérequis PPF</>}
+                </button>
+
+                {preflight && (
+                  <div className={`alert ${preflight.ready ? 'alert-success' : 'alert-warning'} small py-2 mb-2`}>
+                    {preflight.pisteEnv && (
+                      <div className="mb-1">
+                        <span className={`badge ${preflight.pisteEnv === 'production' ? 'bg-danger' : 'bg-secondary'} me-1`}>
+                          {preflight.pisteEnv === 'production' ? 'PRODUCTION' : 'SANDBOX'}
+                        </span>
+                        {preflight.pisteEnv === 'sandbox' && <span className="text-muted">Les dépôts n'atteignent pas le PPF réel.</span>}
+                      </div>
+                    )}
+                    {preflight.blockers.length > 0 && (
+                      <ul className="mb-1 ps-3">
+                        {preflight.blockers.map((b, i) => (
+                          <li key={i} className="text-danger"><i className="bi bi-x-circle me-1"></i>{b}</li>
+                        ))}
+                      </ul>
+                    )}
+                    {preflight.warnings.map((w, i) => (
+                      <div key={i} className="text-warning"><i className="bi bi-exclamation-triangle me-1"></i>{w}</div>
+                    ))}
+                    {preflight.ready && <div className="text-success fw-semibold"><i className="bi bi-check-circle me-1"></i>Prêt pour le dépôt PPF.</div>}
+                  </div>
+                )}
+
+                {invoice.workflowStatus === 'issued' && invoice.facturxPdfUrl &&
+                  (!invoice.ppfStatus || ['not_submitted', 'pending_retry'].includes(invoice.ppfStatus)) && (
+                  <button
+                    className="btn btn-primary btn-sm w-100"
+                    onClick={handleSubmitPpf}
+                    disabled={submittingPpf || (preflight !== null && !preflight.ready)}
+                    title={preflight && !preflight.ready ? 'Résolvez les prérequis avant de déposer' : ''}
+                  >
+                    {submittingPpf
+                      ? <><span className="spinner-border spinner-border-sm me-1" />Dépôt en cours...</>
+                      : <><i className="bi bi-send me-1"></i>Déposer sur Chorus Pro</>}
+                  </button>
+                )}
+              </div>
             )}
           </div>
 

--- a/src/domains/invoices/activity-log.ts
+++ b/src/domains/invoices/activity-log.ts
@@ -12,7 +12,8 @@ export type ActivityAction =
   | 'ppf_submitted'
   | 'ppf_submission_failed'
   | 'ppf_status_updated'
-  | 'ppf_retry_succeeded';
+  | 'ppf_retry_succeeded'
+  | 'ppf_status_polled';
 
 export async function logActivity(params: {
   invoiceId: string;

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,10 @@
     {
       "path": "/api/cron/ppf-receive",
       "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/cron/ppf-status-poll",
+      "schedule": "0 12 * * *"
     }
   ],
   "functions": {
@@ -44,6 +48,9 @@
       "maxDuration": 60
     },
     "src/app/api/cron/ppf-receive/route.ts": {
+      "maxDuration": 60
+    },
+    "src/app/api/cron/ppf-status-poll/route.ts": {
       "maxDuration": 60
     }
   }


### PR DESCRIPTION
## Summary
- **Preflight API** \`GET /api/invoices/[invoiceId]/ppf-preflight\`: validates all conditions before PPF submission without submitting — checks plan (Pro gate), workflow status (must be \`issued\`), transaction type (B2C blocked), SIRET validity (issuer + buyer), Factur-X PDF presence, line items, and PISTE credentials with a live token test. Returns \`{ ready, blockers, warnings, pisteEnv }\`.
- **Status polling cron** \`GET /api/cron/ppf-status-poll\`: polls \`getPpfInvoiceStatus\` for all invoices in \`deposee / en_cours_de_routage / recue\` states, writes status updates to DB, notifies on rejection. Runs daily at noon (registered in \`vercel.json\`).
- **Invoice detail PPF card enhanced**: adds a lifecycle timeline (Déposée → Routage → Reçue → Approuvée → Payée), an inline "Vérifier les prérequis" button that runs the preflight, displays blockers/warnings with sandbox vs production badge, and disables the submit button while blockers exist.

## Switching to production PISTE
1. In Settings → Chorus Pro, set \`pisteEnv\` to \`production\`
2. Enter production \`pisteClientId\`, \`pisteClientSecret\`, \`cproTechLogin\`, \`cproTechPassword\`
3. Use "Tester la connexion" to confirm token acquisition against the production endpoint
4. Run preflight on an issued invoice — it will show PRODUCTION badge and confirm credentials are live

## Test plan
- [ ] Free user → preflight returns blocker "Le dépôt PPF requiert le plan InvoiceOps Pro"
- [ ] Pro user, draft invoice → preflight blocks on workflow status
- [ ] Pro user, B2C issued invoice → preflight blocks on transaction type
- [ ] Pro user, issued B2B invoice, no PISTE creds → preflight blocks on credentials
- [ ] Pro user, issued B2B invoice, sandbox creds → preflight passes with sandbox warning
- [ ] Submit button disabled while preflight has blockers; enabled when \`ready: true\`
- [ ] Status poll cron updates \`deposee\` invoices after Chorus Pro processes them