### PR TITLE
Promote dev → staging: CI branch fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, staging, dev ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, staging, dev ]
 
 jobs:
   test:
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Promotes CI branch fix from dev: targets main/staging/dev (was main/develop), drops Node 18 matrix (libxmljs requires Node 22)