### PR TITLE
Launch readiness: cookie consent, AI extraction UX, e-reporting errors

### DIFF
--- a/src/app/api/billing/quota/route.ts
+++ b/src/app/api/billing/quota/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth-options';
 import { getUserPlan, getMonthlyInvoiceCount, FREE_INVOICE_LIMIT } from '@/lib/subscription';
+import { isLLMConfigured } from '@/lib/llm-router';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -9,13 +10,14 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  const llmConfigured = isLLMConfigured();
   const plan = await getUserPlan(session.user.id);
   if (plan === 'pro') {
-    return NextResponse.json({ plan: 'pro', limit: null, used: null, remaining: null });
+    return NextResponse.json({ plan: 'pro', limit: null, used: null, remaining: null, llmConfigured });
   }
 
   const used = await getMonthlyInvoiceCount(session.user.id);
   const remaining = Math.max(0, FREE_INVOICE_LIMIT - used);
 
-  return NextResponse.json({ plan: 'free', limit: FREE_INVOICE_LIMIT, used, remaining });
+  return NextResponse.json({ plan: 'free', limit: FREE_INVOICE_LIMIT, used, remaining, llmConfigured });
 }

--- a/src/app/api/e-reporting/route.ts
+++ b/src/app/api/e-reporting/route.ts
@@ -52,7 +52,7 @@ export async function POST(req: NextRequest) {
   const data = await aggregateEReportingData(session.user.id, period);
 
   if (!data || data.transactionCount === 0) {
-    return NextResponse.json({ error: 'No B2C invoices found for this period' }, { status: 404 });
+    return NextResponse.json({ error: 'Aucune transaction B2C trouvée pour cette période.' }, { status: 404 });
   }
 
   const xml = buildEReportingXml(data);

--- a/src/app/components/CookieBanner.tsx
+++ b/src/app/components/CookieBanner.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+const CONSENT_KEY = 'invoiceops_cookie_consent';
+
+export type CookieConsent = 'accepted' | 'declined' | null;
+
+export function getCookieConsent(): CookieConsent {
+  if (typeof window === 'undefined') return null;
+  return (localStorage.getItem(CONSENT_KEY) as CookieConsent) ?? null;
+}
+
+export default function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem(CONSENT_KEY)) setVisible(true);
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem(CONSENT_KEY, 'accepted');
+    setVisible(false);
+  };
+
+  const decline = () => {
+    localStorage.setItem(CONSENT_KEY, 'declined');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        background: '#1a1d23',
+        borderTop: '1px solid #2d3139',
+        padding: '1rem 1.5rem',
+      }}
+    >
+      <div className="container-fluid" style={{ maxWidth: 960 }}>
+        <div className="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+          <div className="small text-light" style={{ lineHeight: 1.5 }}>
+            <i className="bi bi-shield-check text-primary me-2"></i>
+            Nous utilisons des cookies pour mesurer l&apos;audience (Google Analytics) et enregistrer des replays
+            anonymisés lors d&apos;erreurs (Sentry). Aucun cookie publicitaire.{' '}
+            <Link href="/privacy-policy" className="text-primary text-decoration-none">
+              Politique de confidentialité
+            </Link>
+          </div>
+          <div className="d-flex gap-2 flex-shrink-0">
+            <button
+              className="btn btn-sm btn-outline-secondary"
+              onClick={decline}
+            >
+              Refuser
+            </button>
+            <button
+              className="btn btn-sm btn-primary"
+              onClick={accept}
+            >
+              Accepter
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/create-invoice/page.tsx
+++ b/src/app/dashboard/create-invoice/page.tsx
@@ -116,7 +116,7 @@ export default function CreateInvoicePage() {
   const [extractionSource, setExtractionSource] = useState<string | null>(null);
   const [suggestNewClient, setSuggestNewClient] = useState<{ name: string; address?: string; email?: string; siret?: string } | null>(null);
   const [creatingClient, setCreatingClient] = useState(false);
-  const [quota, setQuota] = useState<{ plan: string; limit: number | null; used: number | null; remaining: number | null } | null>(null);
+  const [quota, setQuota] = useState<{ plan: string; limit: number | null; used: number | null; remaining: number | null; llmConfigured?: boolean } | null>(null);
   const [siretCheck, setSiretCheck] = useState<{ loading: boolean; result: { valid: boolean; active: boolean; companyName: string | null; error?: string } | null }>({ loading: false, result: null });
 
   const handleDocumentUpload = async (file: File) => {
@@ -520,6 +520,21 @@ export default function CreateInvoicePage() {
                       Saisir manuellement →
                     </button>
                   </div>
+                </>
+              ) : quota?.llmConfigured === false ? (
+                <>
+                  <div className="mb-3" style={{ fontSize: '2.5rem' }}>
+                    <i className="bi bi-robot text-secondary"></i>
+                  </div>
+                  <div className="fw-semibold mb-1">Extraction IA — bientôt disponible</div>
+                  <div className="text-muted small mb-3">Cette fonctionnalité sera activée prochainement. En attendant, saisissez votre facture manuellement.</div>
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={() => setShowUploadZone(false)}
+                  >
+                    Saisir manuellement →
+                  </button>
                 </>
               ) : (
                 <>

--- a/src/app/dashboard/e-reporting/page.tsx
+++ b/src/app/dashboard/e-reporting/page.tsx
@@ -83,6 +83,8 @@ export default function EReportingPage() {
         body: JSON.stringify({ period, submit: false }),
       });
       const data = await res.json();
+      if (res.status === 403) throw new Error('Cette fonctionnalité nécessite un plan Pro. Mettez à niveau dans Paramètres > Abonnement.');
+      if (res.status === 404) throw new Error('Aucune transaction B2C pour cette période — aucun rapport à générer.');
       if (!res.ok) throw new Error(data.error ?? 'Erreur génération');
       setSuccess(`Rapport ${period} généré.`);
       loadPeriods();
@@ -104,6 +106,8 @@ export default function EReportingPage() {
         body: JSON.stringify({ period, submit: true }),
       });
       const data = await res.json();
+      if (res.status === 403) throw new Error('Cette fonctionnalité nécessite un plan Pro. Mettez à niveau dans Paramètres > Abonnement.');
+      if (res.status === 404) throw new Error('Aucune transaction B2C pour cette période — aucun rapport à soumettre.');
       if (!res.ok) throw new Error(data.error ?? 'Erreur soumission');
       setSuccess(`Rapport ${period} soumis — flux n° ${data.numeroFluxDepot}`);
       loadPeriods();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,11 +12,21 @@ import FeedbackButton from "@/app/components/FeedbackButton";
 import { PWAInstallBadge } from "@/app/components/PWAInstallPrompt";
 import OfflineIndicator from "@/app/components/OfflineIndicator";
 import PWAUpdatePrompt from "@/app/components/PWAUpdatePrompt";
-import { useEffect } from "react";
+import CookieBanner, { getCookieConsent } from "@/app/components/CookieBanner";
+import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { GoogleAnalytics } from '@next/third-parties/google';
 
 export default function RootLayout({ children }: { children: React.ReactNode; }) {
+  const [analyticsConsent, setAnalyticsConsent] = useState(false);
+
+  useEffect(() => {
+    setAnalyticsConsent(getCookieConsent() === 'accepted');
+    const onStorage = () => setAnalyticsConsent(getCookieConsent() === 'accepted');
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
   useEffect(() => {
     require("bootstrap/dist/js/bootstrap.bundle.min.js");
     
@@ -233,8 +243,9 @@ export default function RootLayout({ children }: { children: React.ReactNode; })
               <main>{children}</main>
             </>
           )}
+          <CookieBanner />
         </SessionProvider>
-        <GoogleAnalytics gaId="G-VNPY0RYV2B" />
+        {analyticsConsent && <GoogleAnalytics gaId="G-VNPY0RYV2B" />}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- RGPD cookie consent banner (bottom of all pages): accept/decline, links to privacy policy, gates Google Analytics on consent
- AI extraction graceful state: when LLM not configured, show "bientôt disponible" card instead of upload zone that returns 503
- E-reporting error messages translated to French; 403 (Pro required) and 404 (no B2C data) handled with actionable messages