### PR TITLE
Add Langfuse AI observability (traces, tokens, latency, fallback)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "cloudinary": "^2.7.0",
         "csv-parser": "^3.2.0",
         "framer-motion": "^12.23.0",
+        "langfuse": "^3.38.20",
         "next": "^15.5.14",
         "next-auth": "^4.24.12",
         "next-pwa": "^5.6.0",
@@ -13008,6 +13009,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/langfuse": {
+      "version": "3.38.20",
+      "resolved": "https://registry.npmjs.org/langfuse/-/langfuse-3.38.20.tgz",
+      "integrity": "sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==",
+      "license": "MIT",
+      "dependencies": {
+        "langfuse-core": "^3.38.20"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/langfuse-core": {
+      "version": "3.38.20",
+      "resolved": "https://registry.npmjs.org/langfuse-core/-/langfuse-core-3.38.20.tgz",
+      "integrity": "sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mustache": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -13669,6 +13694,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nan": {
       "version": "2.26.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cloudinary": "^2.7.0",
     "csv-parser": "^3.2.0",
     "framer-motion": "^12.23.0",
+    "langfuse": "^3.38.20",
     "next": "^15.5.14",
     "next-auth": "^4.24.12",
     "next-pwa": "^5.6.0",

--- a/src/app/api/invoices/extract/route.ts
+++ b/src/app/api/invoices/extract/route.ts
@@ -97,7 +97,7 @@ export async function POST(req: NextRequest) {
     if (isImage) {
       // Vision model — direct image understanding
       const base64 = buffer.toString('base64');
-      raw = await extractFromImage(base64, mimeType, EXTRACTION_PROMPT);
+      raw = await extractFromImage(base64, mimeType, EXTRACTION_PROMPT, session.user.id);
     } else {
       // PDF — extract text first, then use Mistral (French text model)
       const pdfParse = (await import('pdf-parse')).default;
@@ -111,7 +111,7 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      raw = await extractFromText(pdfText, EXTRACTION_PROMPT);
+      raw = await extractFromText(pdfText, EXTRACTION_PROMPT, session.user.id);
     }
 
     // Strip markdown fences if model wraps in ```json

--- a/src/lib/llm-router.ts
+++ b/src/lib/llm-router.ts
@@ -10,11 +10,25 @@
  * Routing logic per task:
  *  Vision (image OCR) → Groq llama-4-scout-17b  → Ollama gemma3:27b
  *  Text (PDF/French)  → Groq mistral-saba-24b   → Ollama ministral-3:8b
+ *
+ * Observability: each call is traced in Langfuse when LANGFUSE_SECRET_KEY is set.
  */
 
 import OpenAI from 'openai';
+import { Langfuse } from 'langfuse';
 
 export type LLMProvider = 'groq' | 'ollama';
+
+// Singleton Langfuse client — no-ops when env vars are absent
+function getLangfuse(): Langfuse | null {
+  if (!process.env.LANGFUSE_SECRET_KEY || !process.env.LANGFUSE_PUBLIC_KEY) return null;
+  return new Langfuse({
+    secretKey: process.env.LANGFUSE_SECRET_KEY,
+    publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+    baseUrl: process.env.LANGFUSE_BASEURL ?? 'https://cloud.langfuse.com',
+    flushAt: 1, // flush immediately in serverless
+  });
+}
 
 // Which errors should trigger a fallback (not user errors)
 function isFallbackWorthy(err: unknown): boolean {
@@ -72,23 +86,83 @@ const TEXT_MODELS: Record<LLMProvider, string> = {
 
 type ChatMessages = OpenAI.Chat.ChatCompletionMessageParam[];
 
+interface RunOptions {
+  taskName: string; // shown as trace name in Langfuse
+  userId?: string;
+  usedFallback?: boolean;
+}
+
 async function runWithFallback(
   buildMessages: (provider: LLMProvider) => ChatMessages,
   modelMap: Record<LLMProvider, string>,
+  options: RunOptions,
 ): Promise<string> {
   const primary = getPrimaryProvider();
   const fallback = getFallbackProvider();
+  const langfuse = getLangfuse();
+
+  const trace = langfuse?.trace({
+    name: options.taskName,
+    userId: options.userId,
+    tags: ['llm-extraction'],
+  });
+
+  async function callProvider(provider: LLMProvider, isFallback: boolean): Promise<string> {
+    const model = modelMap[provider];
+    const messages = buildMessages(provider);
+    const client = buildClient(provider);
+
+    const generation = trace?.generation({
+      name: isFallback ? 'fallback-call' : 'primary-call',
+      model,
+      input: messages,
+      metadata: { provider, isFallback },
+    });
+
+    const start = Date.now();
+    try {
+      const response = await client.chat.completions.create({
+        model,
+        max_tokens: 1500,
+        messages,
+      });
+      const latencyMs = Date.now() - start;
+      const content = response.choices[0]?.message?.content ?? '';
+
+      generation?.end({
+        output: content,
+        usage: {
+          input: response.usage?.prompt_tokens,
+          output: response.usage?.completion_tokens,
+          total: response.usage?.total_tokens,
+          unit: 'TOKENS',
+        },
+        metadata: { latencyMs, provider, model, isFallback },
+      });
+
+      return content;
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      const errMsg = err instanceof Error ? err.message : String(err);
+      generation?.end({
+        output: { error: errMsg },
+        level: 'ERROR',
+        statusMessage: errMsg,
+        metadata: { latencyMs, provider, model, isFallback },
+      });
+      throw err;
+    }
+  }
 
   try {
-    const client = buildClient(primary);
-    const response = await client.chat.completions.create({
-      model: modelMap[primary],
-      max_tokens: 1500,
-      messages: buildMessages(primary),
-    });
-    return response.choices[0]?.message?.content ?? '';
+    const result = await callProvider(primary, false);
+    await langfuse?.shutdownAsync();
+    return result;
   } catch (primaryErr) {
-    if (!isFallbackWorthy(primaryErr)) throw primaryErr;
+    if (!isFallbackWorthy(primaryErr)) {
+      await langfuse?.shutdownAsync();
+      throw primaryErr;
+    }
 
     const reason = primaryErr instanceof OpenAI.APIError
       ? `status ${primaryErr.status}`
@@ -96,13 +170,14 @@ async function runWithFallback(
 
     console.warn(`[LLMRouter] Primary (${primary}) failed (${reason}), switching to fallback (${fallback})`);
 
-    const fallbackClient = buildClient(fallback);
-    const fallbackResponse = await fallbackClient.chat.completions.create({
-      model: modelMap[fallback],
-      max_tokens: 1500,
-      messages: buildMessages(fallback),
-    });
-    return fallbackResponse.choices[0]?.message?.content ?? '';
+    try {
+      const result = await callProvider(fallback, true);
+      await langfuse?.shutdownAsync();
+      return result;
+    } catch (fallbackErr) {
+      await langfuse?.shutdownAsync();
+      throw fallbackErr;
+    }
   }
 }
 
@@ -114,6 +189,7 @@ export async function extractFromImage(
   base64: string,
   mimeType: string,
   prompt: string,
+  userId?: string,
 ): Promise<string> {
   return runWithFallback(
     () => [
@@ -126,6 +202,7 @@ export async function extractFromImage(
       },
     ],
     VISION_MODELS,
+    { taskName: 'invoice-extraction-vision', userId },
   );
 }
 
@@ -136,10 +213,12 @@ export async function extractFromImage(
 export async function extractFromText(
   text: string,
   prompt: string,
+  userId?: string,
 ): Promise<string> {
   return runWithFallback(
     () => [{ role: 'user', content: `${prompt}\n\n---\n\n${text}` }],
     TEXT_MODELS,
+    { taskName: 'invoice-extraction-text', userId },
   );
 }
 


### PR DESCRIPTION
## Summary
- Install langfuse SDK and instrument LLM router with traces per extraction call
- Each call tracked: provider, model, input/output tokens, latency (ms), fallback flag
- userId passed through so Langfuse dashboard shows per-user extraction activity
- No-ops gracefully when LANGFUSE_SECRET_KEY / LANGFUSE_PUBLIC_KEY are not set
- flushAt: 1 ensures traces are flushed immediately in Vercel serverless context