### PR TITLE
Fix Sentry deprecation: migrate to instrumentation-client.ts

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,12 +3,12 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,
-  tracesSampleRate: 0.2,       // 20% of transactions for performance
-  replaysOnErrorSampleRate: 1, // Full replay on every error
+  tracesSampleRate: 0.2,
+  replaysOnErrorSampleRate: 1,
   replaysSessionSampleRate: 0.05,
   integrations: [
     Sentry.replayIntegration({
-      maskAllText: true,   // GDPR: mask all text in replays
+      maskAllText: true,
       blockAllMedia: true,
     }),
   ],

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,8 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config');
+  }
+}


### PR DESCRIPTION
## Summary
- Rename sentry.client.config.ts → instrumentation-client.ts (Next.js 15 / Turbopack standard)
- Add instrumentation.ts to wire server and edge Sentry inits via register() hook
- Eliminates the [@sentry/nextjs] DEPRECATION WARNING during build