### PR TITLE
feat: compliance gating and TVA code removal

### DIFF
--- a/src/app/api/cron/e-reporting/route.ts
+++ b/src/app/api/cron/e-reporting/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { aggregateEReportingData, buildEReportingXml } from '@/domains/compliance/e-reporting/generate';
 import { submitInvoiceToPpf } from '@/lib/piste-api';
+import { isPro } from '@/lib/subscription';
 
 // POST /api/cron/e-reporting
 // Runs on the 1st of each month — auto-submits e-reporting for the previous month.
@@ -16,6 +17,10 @@ export async function POST(req: NextRequest) {
   const now = new Date();
   const prevMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
   const period = `${prevMonth.getFullYear()}-${String(prevMonth.getMonth() + 1).padStart(2, '0')}`;
+
+  if (!process.env.PISTE_CLIENT_ID || !process.env.PISTE_CLIENT_SECRET) {
+    return NextResponse.json({ error: 'PISTE credentials not configured' }, { status: 500 });
+  }
 
   // Find all users who have B2C invoices in the period that haven't been reported yet
   const users = await prisma.user.findMany({
@@ -44,6 +49,8 @@ export async function POST(req: NextRequest) {
 
   for (const user of users) {
     try {
+      if (!(await isPro(user.id))) continue;
+
       const data = await aggregateEReportingData(user.id, period);
       if (!data || data.transactionCount === 0) continue;
 

--- a/src/app/api/cron/generate-urssaf-reports/route.ts
+++ b/src/app/api/cron/generate-urssaf-reports/route.ts
@@ -21,20 +21,10 @@ const getIncomeTaxRate = (microEntrepreneurType: string) => {
   }
 };
 
-// Helper to get TVA thresholds (2024 values)
-const getTvaThreshold = (microEntrepreneurType: string) => {
-  switch (microEntrepreneurType) {
-    case 'COMMERCANT': return 91900; // Commercial activities
-    case 'PRESTATAIRE': return 36800; // Service activities (BIC)
-    case 'LIBERAL': return 36800; // Liberal activities (BNC)
-    default: return 0;
-  }
-};
-
 // Helper to create in-app notifications
 const createNotification = async (
   userId: string, 
-  type: 'URSSAF_REMINDER' | 'TVA_THRESHOLD_WARNING' | 'TVA_THRESHOLD_EXCEEDED',
+  type: 'URSSAF_REMINDER',
   title: string,
   message: string,
   actionUrl?: string,
@@ -74,7 +64,6 @@ export async function GET(request: Request) {
         fiscalRegime: true,
         microEntrepreneurType: true,
         declarationFrequency: true,
-        tvaNumber: true,
       },
     });
 
@@ -150,17 +139,6 @@ export async function GET(request: Request) {
       const impotRevenu = caTotal * incomeTaxRate;
       const revenuNet = caTotal - cotisations - impotRevenu;
 
-      // Check TVA threshold status
-      const tvaThreshold = getTvaThreshold(user.microEntrepreneurType);
-      const tvaApplicable = caTotal >= tvaThreshold;
-      
-      let alerte = 'Sous seuil de TVA';
-      if (tvaApplicable) {
-        alerte = 'Seuil TVA dépassé - TVA applicable';
-      } else if (caTotal >= tvaThreshold * 0.8) {
-        alerte = 'Proche du seuil TVA (80% atteint)';
-      }
-
       // Calculate next declaration deadline
       const nextDeclarationDate = new Date(endDate);
       nextDeclarationDate.setMonth(nextDeclarationDate.getMonth() + 1);
@@ -184,8 +162,6 @@ export async function GET(request: Request) {
         tauxImpot: parseFloat((incomeTaxRate * 100).toFixed(1)),
         impotRevenu: parseFloat(impotRevenu.toFixed(2)),
         revenuNet: parseFloat(revenuNet.toFixed(2)),
-        tvaApplicable,
-        alerte,
         message,
         disclaimer: 'Ce rapport est une estimation basée sur vos factures payées. Vérifiez toujours sur autoentrepreneur.urssaf.fr.',
         paidInvoicesDisclaimer: `Seules les factures payées entre le ${startDate.toLocaleDateString('fr-FR')} et le ${endDate.toLocaleDateString('fr-FR')} sont incluses.`,
@@ -216,27 +192,6 @@ export async function GET(request: Request) {
           declarationType,
         }
       );
-
-      // Create TVA threshold notifications if needed
-      if (tvaApplicable && !user.tvaNumber) {
-        await createNotification(
-          user.id,
-          'TVA_THRESHOLD_EXCEEDED',
-          '🚨 Seuil TVA dépassé !',
-          `Votre CA annuel a dépassé ${tvaThreshold}€. Vous devez vous enregistrer à la TVA et mettre à jour votre profil.`,
-          '/dashboard/settings',
-          { threshold: tvaThreshold, currentCA: caTotal }
-        );
-      } else if (caTotal >= tvaThreshold * 0.8 && !user.tvaNumber) {
-        await createNotification(
-          user.id,
-          'TVA_THRESHOLD_WARNING', 
-          '⚠️ Seuil TVA proche',
-          `Attention: vous approchez du seuil TVA (${((caTotal / tvaThreshold) * 100).toFixed(1)}% atteint). Préparez-vous à devenir redevable de la TVA.`,
-          '/dashboard/reports',
-          { threshold: tvaThreshold, currentCA: caTotal, percentage: (caTotal / tvaThreshold) * 100 }
-        );
-      }
 
     }
 

--- a/src/app/api/e-reporting/route.ts
+++ b/src/app/api/e-reporting/route.ts
@@ -12,6 +12,13 @@ export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  if (!(await isPro(session.user.id))) {
+    return NextResponse.json(
+      { error: 'E-reporting requires an InvoiceOps Pro plan.', upgrade: true },
+      { status: 403 }
+    );
+  }
+
   const period = req.nextUrl.searchParams.get('period');
   if (!period || !/^\d{4}-\d{2}$/.test(period)) {
     return NextResponse.json({ error: 'period param required (YYYY-MM)' }, { status: 400 });

--- a/src/app/api/received-invoices/route.ts
+++ b/src/app/api/received-invoices/route.ts
@@ -2,12 +2,20 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth-options';
 import { prisma } from '@/lib/prisma';
+import { isPro } from '@/lib/subscription';
 
 // GET /api/received-invoices?unread=true&limit=50&page=1
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  if (!(await isPro(session.user.id))) {
+    return NextResponse.json(
+      { error: 'Received invoices (Chorus Pro) require an InvoiceOps Pro plan.', upgrade: true },
+      { status: 403 }
+    );
   }
 
   const { searchParams } = new URL(request.url);
@@ -52,6 +60,13 @@ export async function PATCH(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  if (!(await isPro(session.user.id))) {
+    return NextResponse.json(
+      { error: 'Received invoices (Chorus Pro) require an InvoiceOps Pro plan.', upgrade: true },
+      { status: 403 }
+    );
   }
 
   await prisma.receivedInvoice.updateMany({

--- a/src/app/api/reports/urssaf-reports/[id]/route.ts
+++ b/src/app/api/reports/urssaf-reports/[id]/route.ts
@@ -2,6 +2,7 @@ import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth-options';
 import { NextResponse } from 'next/server';
+import { isPro } from '@/lib/subscription';
 
 
 export async function GET(
@@ -12,6 +13,13 @@ export async function GET(
 
   if (!session || !session.user || !session.user.id) {
     return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  if (!(await isPro(session.user.id))) {
+    return NextResponse.json(
+      { error: 'URSSAF reports require an InvoiceOps Pro plan.', upgrade: true },
+      { status: 403 }
+    );
   }
 
   const userId = session.user.id;

--- a/src/app/api/reports/urssaf-reports/route.ts
+++ b/src/app/api/reports/urssaf-reports/route.ts
@@ -2,6 +2,7 @@ import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth-options';
 import { NextResponse } from 'next/server';
+import { isPro } from '@/lib/subscription';
 
 
 export async function GET(request: Request) {
@@ -9,6 +10,13 @@ export async function GET(request: Request) {
 
   if (!session || !session.user || !session.user.id) {
     return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  if (!(await isPro(session.user.id))) {
+    return NextResponse.json(
+      { error: 'URSSAF reports require an InvoiceOps Pro plan.', upgrade: true },
+      { status: 403 }
+    );
   }
 
   const userId = session.user.id;


### PR DESCRIPTION
## Summary

- **Strip TVA code** from `cron/generate-urssaf-reports`: removed `getTvaThreshold` helper, `tvaApplicable`/`alerte` variables, TVA fields from report data, and both `TVA_THRESHOLD_EXCEEDED`/`TVA_THRESHOLD_WARNING` notification blocks. URSSAF_REMINDER notification kept.
- **Gate `GET /api/e-reporting`** with `isPro()` (POST was already gated). Free users get 403 with `upgrade: true`.
- **Gate `GET /api/reports/urssaf-reports`** and **`GET /api/reports/urssaf-reports/[id]`** — URSSAF reports are a Pro feature.
- **Gate `GET` and `PATCH /api/received-invoices`** — Chorus Pro received invoices are Pro-only.
- **`cron/e-reporting`**: add per-user `isPro()` skip before PISTE submission, and a startup guard that returns 500 if `PISTE_CLIENT_ID`/`PISTE_CLIENT_SECRET` are missing.

## Test plan

- [ ] Free user hitting `GET /api/e-reporting?period=2026-04` returns 403 `{ upgrade: true }`
- [ ] Pro user hitting same endpoint returns period summary
- [ ] Free user hitting `GET /api/reports/urssaf-reports` returns 403
- [ ] Free user hitting `GET /api/received-invoices` returns 403
- [ ] Cron `POST /api/cron/e-reporting` with missing PISTE vars returns 500 early
- [ ] Cron skips non-Pro users without attempting PISTE submission
- [ ] `generate-urssaf-reports` cron no longer references TVA thresholds or sends TVA notifications