### PR TITLE
feat: distinguish login errors — no account vs wrong password

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
 const FEATURES = [
@@ -11,8 +11,9 @@ const FEATURES = [
   { icon: "bi-graph-up-arrow", text: "Pilotage du workflow de bout en bout" },
 ];
 
-export default function Register() {
-  const [email, setEmail] = useState("");
+function RegisterContent() {
+  const searchParams = useSearchParams();
+  const [email, setEmail] = useState(searchParams.get('email') ?? "");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
@@ -560,5 +561,19 @@ export default function Register() {
         }
       `}</style>
     </div>
+  );
+}
+
+export default function Register() {
+  return (
+    <Suspense fallback={
+      <div className="d-flex justify-content-center align-items-center vh-100">
+        <div className="spinner-border" role="status">
+          <span className="visually-hidden">Chargement...</span>
+        </div>
+      </div>
+    }>
+      <RegisterContent />
+    </Suspense>
   );
 }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -37,8 +37,12 @@ function SignInContent() {
       setError("Votre email n'est pas encore vérifié. Consultez votre boîte mail ou renvoyez le lien ci-dessous.");
     } else if (result?.error === 'RATE_LIMITED') {
       setError("Trop de tentatives. Attendez quelques minutes avant de réessayer.");
+    } else if (result?.error === 'USER_NOT_FOUND') {
+      setError("USER_NOT_FOUND");
+    } else if (result?.error === 'WRONG_PASSWORD') {
+      setError("Mot de passe incorrect. Veuillez réessayer ou réinitialisez votre mot de passe.");
     } else if (result?.error) {
-      setError("Email ou mot de passe incorrect. Veuillez réessayer.");
+      setError("Une erreur inattendue est survenue. Veuillez réessayer.");
     } else {
       router.push("/dashboard");
     }
@@ -241,7 +245,16 @@ function SignInContent() {
               Inscription réussie ! Un email de vérification a été envoyé. Vérifiez votre boîte mail.
             </div>
           )}
-          {error && (
+          {error === 'USER_NOT_FOUND' && (
+            <div className="alert alert-warning mb-4">
+              <i className="bi bi-person-x me-2"></i>
+              Aucun compte trouvé avec cette adresse email.{' '}
+              <Link href={`/auth/register?email=${encodeURIComponent(email)}`} style={{ color: 'inherit', fontWeight: 600 }}>
+                Créer un compte ?
+              </Link>
+            </div>
+          )}
+          {error && error !== 'USER_NOT_FOUND' && (
             <div className="alert alert-danger mb-4">
               <i className="bi bi-exclamation-triangle me-2"></i>
               {error}

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -33,13 +33,13 @@ export const authOptions = {
         const user = await prisma.user.findUnique({ where: { email: credentials.email } });
 
         if (!user || !user.password) {
-          return null;
+          throw new Error('USER_NOT_FOUND');
         }
 
         const isPasswordValid = await bcrypt.compare(credentials.password, user.password);
 
         if (!isPasswordValid) {
-          return null;
+          throw new Error('WRONG_PASSWORD');
         }
 
         // Block unverified accounts (RESEND_API_KEY must be configured for this to be enforced)


### PR DESCRIPTION
## Summary

- **`authorize()` in `auth-options.ts`**: now throws `USER_NOT_FOUND` when the email doesn't exist in the DB, and `WRONG_PASSWORD` when the password doesn't match. Previously both returned `null` and produced the same generic error.
- **Sign-in page**: 
  - `USER_NOT_FOUND` → amber warning banner: *"Aucun compte trouvé avec cette adresse email. Créer un compte ?"* with a link to `/auth/register?email=<prefilled>`
  - `WRONG_PASSWORD` → red error: *"Mot de passe incorrect. Veuillez réessayer ou réinitialisez votre mot de passe."*
  - Other/unknown errors → *"Une erreur inattendue est survenue."*
- **Register page**: wrapped in `Suspense`, reads `?email=` query param and pre-fills the email field so the sign-in → register handoff is seamless.

## Test plan

- [ ] Login with unknown email → amber banner with "Créer un compte?" link
- [ ] Clicking link goes to `/auth/register` with email pre-filled
- [ ] Login with correct email + wrong password → red "Mot de passe incorrect" message
- [ ] Successful login redirects to `/dashboard`
- [ ] Rate limit error still works (10 attempts / 15 min)
- [ ] Email not verified error still shows resend button