### PR TITLE
Fix: make Cloudinary upload non-fatal in invoice issue route

### DIFF
--- a/src/app/api/invoices/[invoiceId]/issue/route.tsx
+++ b/src/app/api/invoices/[invoiceId]/issue/route.tsx
@@ -114,15 +114,7 @@ export async function POST(
       },
     });
 
-    let pdfBuffer: Buffer;
-    try {
-      pdfBuffer = await renderInvoicePdfBuffer(invoice);
-    } catch (e: unknown) {
-      let msg: string;
-      try { msg = JSON.stringify(e); } catch { msg = String(e); }
-      return NextResponse.json({ error: `PDF render failed: ${msg}`, step: 'pdf' }, { status: 500 });
-    }
-
+    const pdfBuffer = await renderInvoicePdfBuffer(invoice);
     const deliveryAddr = invoice.deliveryAddress
       ? (invoice.deliveryAddress as any)?.address ?? null
       : null;
@@ -209,9 +201,9 @@ export async function POST(
           `facturx-${invoice.id}-xml`
         );
       } catch (e: unknown) {
-        let msg: string;
-        try { msg = JSON.stringify(e); } catch { msg = String(e); }
-        return NextResponse.json({ error: `Cloudinary upload failed: ${msg}`, step: 'cloudinary' }, { status: 500 });
+        // Non-fatal: log but don't block invoice issuance — URLs will remain null
+        const detail = (() => { try { return JSON.stringify(e); } catch { return String(e); } })();
+        console.error('Cloudinary upload failed (non-fatal):', detail);
       }
     }
 
@@ -264,7 +256,9 @@ export async function POST(
       readiness,
     });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = error instanceof Error
+      ? error.message
+      : (() => { try { return JSON.stringify(error); } catch { return String(error); } })();
     console.error('Error issuing invoice:', msg, error);
     return NextResponse.json({ error: msg }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- Root cause: Cloudinary SDK throws plain `{ error: { message, http_code } }` objects on auth/upload failure, not `Error` instances — causing `String(error)` to return `[object Object]` and a cryptic 500
- Fix: wrap Cloudinary uploads in a non-fatal try/catch; log the failure and continue without URLs
- Invoice issuance succeeds regardless of Cloudinary availability (URLs will be null if upload fails)
- Improved outer catch to JSON.stringify plain-object errors for better observability

## Test plan
- [ ] POST /api/invoices/:id/issue → 200 when Cloudinary is unreachable/misconfigured
- [ ] Invoice status becomes `issued`, pdfUrl/facturxPdfUrl are null when upload fails