### PR TITLE
Fix: make Cloudinary upload non-fatal in invoice issue route

### DIFF
--- a/src/app/api/invoices/[invoiceId]/issue/route.tsx
+++ b/src/app/api/invoices/[invoiceId]/issue/route.tsx
@@ -209,9 +209,9 @@ export async function POST(
           `facturx-${invoice.id}-xml`
         );
       } catch (e: unknown) {
-        let msg: string;
-        try { msg = JSON.stringify(e); } catch { msg = String(e); }
-        return NextResponse.json({ error: `Cloudinary upload failed: ${msg}`, step: 'cloudinary' }, { status: 500 });
+        // Non-fatal: log but don't block invoice issuance — URLs will remain null
+        const detail = (() => { try { return JSON.stringify(e); } catch { return String(e); } })();
+        console.error('Cloudinary upload failed (non-fatal):', detail);
       }
     }
 
@@ -264,7 +264,9 @@ export async function POST(
       readiness,
     });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = error instanceof Error
+      ? error.message
+      : (() => { try { return JSON.stringify(error); } catch { return String(error); } })();
     console.error('Error issuing invoice:', msg, error);
     return NextResponse.json({ error: msg }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- Root cause: Cloudinary SDK throws plain `{ error: { message, http_code } }` objects (not `Error` instances) on auth/upload failure — `String(plainObj)` produces `[object Object]`, masking the real error
- Cloudinary upload failure should not block invoice issuance — wrapped in non-fatal try/catch; logs the detail and continues without URLs
- Improved outer catch to JSON.stringify plain-object errors for better observability

## Test plan
- [ ] POST /api/invoices/:id/issue → 200 even when Cloudinary upload fails
- [ ] Invoice status becomes `issued`, pdfUrl null when Cloudinary unavailable