### PR TITLE
Fix: add error handling to billing checkout and portal routes

### DIFF
--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -5,56 +5,65 @@ import { authOptions } from '@/lib/auth-options';
 import { prisma } from '@/lib/prisma';
 
 export async function POST(request: Request) {
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  try {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return NextResponse.json({ error: 'Billing not configured' }, { status: 503 });
+    }
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2025-06-30.basil' });
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
-  const priceId = process.env.STRIPE_PRO_PRICE_ID;
-  if (!priceId) {
-    return NextResponse.json({ error: 'Billing not configured' }, { status: 503 });
-  }
+    const priceId = process.env.STRIPE_PRO_PRICE_ID;
+    if (!priceId) {
+      return NextResponse.json({ error: 'Billing not configured' }, { status: 503 });
+    }
 
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { email: true, stripePlatformCustomerId: true, subscriptionStatus: true },
-  });
-  if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 });
-  }
-
-  // Already active — send to portal instead
-  if (user.subscriptionStatus === 'active' || user.subscriptionStatus === 'trialing') {
-    return NextResponse.json({ error: 'Already subscribed' }, { status: 400 });
-  }
-
-  const { successUrl, cancelUrl } = await request.json().catch(() => ({} as Record<string, string>));
-
-  let customerId = user.stripePlatformCustomerId;
-  if (!customerId) {
-    const customer = await stripe.customers.create({
-      email: user.email ?? undefined,
-      metadata: { userId: session.user.id },
-    });
-    customerId = customer.id;
-    await prisma.user.update({
+    const user = await prisma.user.findUnique({
       where: { id: session.user.id },
-      data: { stripePlatformCustomerId: customerId },
+      select: { email: true, stripePlatformCustomerId: true, subscriptionStatus: true },
     });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // Already active — send to portal instead
+    if (user.subscriptionStatus === 'active' || user.subscriptionStatus === 'trialing') {
+      return NextResponse.json({ error: 'Already subscribed' }, { status: 400 });
+    }
+
+    const { successUrl, cancelUrl } = await request.json().catch(() => ({} as Record<string, string>));
+
+    let customerId = user.stripePlatformCustomerId;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: user.email ?? undefined,
+        metadata: { userId: session.user.id },
+      });
+      customerId = customer.id;
+      await prisma.user.update({
+        where: { id: session.user.id },
+        data: { stripePlatformCustomerId: customerId },
+      });
+    }
+
+    const checkoutSession = await stripe.checkout.sessions.create({
+      customer: customerId,
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: successUrl ?? `${process.env.NEXTAUTH_URL}/dashboard/settings?billing=success`,
+      cancel_url: cancelUrl ?? `${process.env.NEXTAUTH_URL}/dashboard/settings?billing=cancelled`,
+      subscription_data: {
+        trial_period_days: 14,
+        metadata: { userId: session.user.id },
+      },
+    });
+
+    return NextResponse.json({ url: checkoutSession.url });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : JSON.stringify(error);
+    console.error('Billing checkout error:', msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
-
-  const checkoutSession = await stripe.checkout.sessions.create({
-    customer: customerId,
-    mode: 'subscription',
-    line_items: [{ price: priceId, quantity: 1 }],
-    success_url: successUrl ?? `${process.env.NEXTAUTH_URL}/dashboard/settings?billing=success`,
-    cancel_url: cancelUrl ?? `${process.env.NEXTAUTH_URL}/dashboard/settings?billing=cancelled`,
-    subscription_data: {
-      trial_period_days: 14,
-      metadata: { userId: session.user.id },
-    },
-  });
-
-  return NextResponse.json({ url: checkoutSession.url });
 }

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -5,25 +5,34 @@ import { authOptions } from '@/lib/auth-options';
 import { prisma } from '@/lib/prisma';
 
 export async function POST() {
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2025-06-30.basil' });
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  try {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return NextResponse.json({ error: 'Billing not configured' }, { status: 503 });
+    }
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2025-06-30.basil' });
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { stripePlatformCustomerId: true },
+    });
+
+    if (!user?.stripePlatformCustomerId) {
+      return NextResponse.json({ error: 'No billing account found' }, { status: 404 });
+    }
+
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: user.stripePlatformCustomerId,
+      return_url: `${process.env.NEXTAUTH_URL}/dashboard/settings`,
+    });
+
+    return NextResponse.json({ url: portalSession.url });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : JSON.stringify(error);
+    console.error('Billing portal error:', msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
-
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { stripePlatformCustomerId: true },
-  });
-
-  if (!user?.stripePlatformCustomerId) {
-    return NextResponse.json({ error: 'No billing account found' }, { status: 404 });
-  }
-
-  const portalSession = await stripe.billingPortal.sessions.create({
-    customer: user.stripePlatformCustomerId,
-    return_url: `${process.env.NEXTAUTH_URL}/dashboard/settings`,
-  });
-
-  return NextResponse.json({ url: portalSession.url });
 }


### PR DESCRIPTION
## Summary
- Billing checkout/portal routes had no try/catch — any Stripe API error returned a silent 500 with empty body
- Added try/catch to both routes, returning the actual error message in the JSON body
- Added explicit guard for missing STRIPE_SECRET_KEY (returns 503 instead of runtime crash)

## Test plan
- [ ] POST /api/billing/checkout → returns readable error instead of empty 500
- [ ] Root cause of checkout 500 visible in response body