### PR TITLE
Feat: BTP domain — autoliquidation, factures de situation, retenue de garantie, Chorus Pro routing

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,9 @@ model User {
   subscriptionStatus        String    @default("free")  // free | trialing | active | past_due | canceled
   planId                    String    @default("free")  // free | pro
   subscriptionPeriodEnd     DateTime?
+  // Automatic payment reminder preferences
+  reminderEnabled           Boolean   @default(true)
+  reminderSchedule          Json?     // [{ triggerDays: number, label: string }] — null = use default ladder
   // Per-tenant Chorus Pro / PISTE credentials (passwords AES-256-GCM encrypted)
   cproTechLogin       String?
   cproTechPassword    String?
@@ -170,6 +173,25 @@ model Invoice {
   ppfSubmittedAt      DateTime?
   ppfLastEventAt      DateTime?
   ppfError            String?
+  // Automatic payment reminder tracking
+  reminderEnabled     Boolean   @default(true)
+  reminderCount       Int       @default(0)
+  lastReminderSentAt  DateTime?
+  nextReminderAt      DateTime?
+
+  // ── BTP sub-contractor fields ─────────────────────────────
+  btpInvoiceType          BtpInvoiceType @default(standard)
+  isAutoliquidation       Boolean        @default(false)
+  retenueGarantieRate     Decimal?       @db.Decimal(5, 2)
+  retenueGarantieAmount   Decimal?       @db.Decimal(12, 2)
+  situationNumber         Int?
+  referenceContract       String?
+  previousCumulativeAmount Decimal?      @db.Decimal(12, 2)
+  cumulativeAmount        Decimal?       @db.Decimal(12, 2)
+  previousInvoiceNumber   String?
+  // Chorus Pro / B2G routing fields (Marchés Publics)
+  codeService             String?
+  numeroEngagement        String?
 }
 
 model InvoiceItem {
@@ -273,6 +295,12 @@ enum TransactionType {
   B2B
   B2C
   B2G
+}
+
+enum BtpInvoiceType {
+  standard
+  situation
+  autoliquidation
 }
 
 enum PpfStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,9 +57,6 @@ model User {
   subscriptionStatus        String    @default("free")  // free | trialing | active | past_due | canceled
   planId                    String    @default("free")  // free | pro
   subscriptionPeriodEnd     DateTime?
-  // Automatic payment reminder preferences
-  reminderEnabled           Boolean   @default(true)
-  reminderSchedule          Json?     // [{ triggerDays: number, label: string }] — null = use default ladder
   // Per-tenant Chorus Pro / PISTE credentials (passwords AES-256-GCM encrypted)
   cproTechLogin       String?
   cproTechPassword    String?
@@ -173,11 +170,6 @@ model Invoice {
   ppfSubmittedAt      DateTime?
   ppfLastEventAt      DateTime?
   ppfError            String?
-  // Automatic payment reminder tracking
-  reminderEnabled     Boolean   @default(true)
-  reminderCount       Int       @default(0)
-  lastReminderSentAt  DateTime?
-  nextReminderAt      DateTime?
 
   // ── BTP sub-contractor fields ─────────────────────────────
   btpInvoiceType          BtpInvoiceType @default(standard)

--- a/src/app/api/invoices/[invoiceId]/issue/route.tsx
+++ b/src/app/api/invoices/[invoiceId]/issue/route.tsx
@@ -9,7 +9,6 @@ import { generateFacturxDocument } from '@/domains/invoices/facturx';
 import { logActivity } from '@/domains/invoices/activity-log';
 import { sendInvoiceEmail } from '@/lib/email-service';
 import { renderInvoicePdfBuffer } from '@/lib/facturx-pdf-generator';
-import { computeNextReminderDate, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
 
 const safeToNumber = (value: unknown) => {
   if (value === null || value === undefined || value === '') return 0;
@@ -40,16 +39,10 @@ export async function POST(
   const { invoiceId } = await params;
 
   try {
-    const [invoice, issuer] = await Promise.all([
-      prisma.invoice.findFirst({
-        where: { id: invoiceId, userId: session.user.id },
-        include: { client: true, items: true },
-      }),
-      prisma.user.findUnique({
-        where: { id: session.user.id },
-        select: { reminderEnabled: true, reminderSchedule: true },
-      }),
-    ]);
+    const invoice = await prisma.invoice.findFirst({
+      where: { id: invoiceId, userId: session.user.id },
+      include: { client: true, items: true },
+    });
 
     if (!invoice) {
       return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
@@ -219,12 +212,6 @@ export async function POST(
       }
     }
 
-    // Compute first reminder date from user's schedule (resets on issuance)
-    const reminderSchedule = parseReminderSchedule(issuer?.reminderSchedule);
-    const nextReminderAt = issuer?.reminderEnabled !== false && invoice.reminderEnabled
-      ? computeNextReminderDate(invoice.dueDate, 0, reminderSchedule)
-      : null;
-
     const updatedInvoice = await prisma.invoice.update({
       where: { id: invoice.id },
       data: {
@@ -237,8 +224,6 @@ export async function POST(
         facturxStatus: 'generated',
         facturxGeneratedAt: new Date(),
         facturxValidationErrors: [],
-        reminderCount: 0,
-        nextReminderAt,
       },
       include: { client: true, items: true },
     });

--- a/src/app/api/invoices/[invoiceId]/issue/route.tsx
+++ b/src/app/api/invoices/[invoiceId]/issue/route.tsx
@@ -2,33 +2,20 @@ import prisma from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth-options';
-import { renderToStream } from '@react-pdf/renderer';
 
-import InvoicePdf from '@/app/components/InvoicePdf';
 import cloudinary from '@/lib/cloudinary';
 import { evaluateInvoiceReadiness } from '@/domains/invoices/invoice-readiness';
 import { generateFacturxDocument } from '@/domains/invoices/facturx';
 import { logActivity } from '@/domains/invoices/activity-log';
 import { sendInvoiceEmail } from '@/lib/email-service';
-
+import { renderInvoicePdfBuffer } from '@/lib/facturx-pdf-generator';
+import { computeNextReminderDate, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
 
 const safeToNumber = (value: unknown) => {
   if (value === null || value === undefined || value === '') return 0;
   const numeric = Number(value);
   return Number.isNaN(numeric) ? 0 : numeric;
 };
-
-async function renderInvoicePdfBuffer(invoice: any) {
-  const doc = <InvoicePdf invoice={invoice} />;
-  const stream = await renderToStream(doc);
-
-  return await new Promise<Buffer>((resolve, reject) => {
-    const buffers: Uint8Array[] = [];
-    stream.on('data', (chunk) => buffers.push(chunk));
-    stream.on('end', () => resolve(Buffer.concat(buffers)));
-    stream.on('error', (error) => reject(error));
-  });
-}
 
 async function uploadRawAsset(dataUri: string, folder: string, publicId: string) {
   const uploadResult = await cloudinary.uploader.upload(dataUri, {
@@ -53,10 +40,16 @@ export async function POST(
   const { invoiceId } = await params;
 
   try {
-    const invoice = await prisma.invoice.findFirst({
-      where: { id: invoiceId, userId: session.user.id },
-      include: { client: true, items: true },
-    });
+    const [invoice, issuer] = await Promise.all([
+      prisma.invoice.findFirst({
+        where: { id: invoiceId, userId: session.user.id },
+        include: { client: true, items: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { reminderEnabled: true, reminderSchedule: true },
+      }),
+    ]);
 
     if (!invoice) {
       return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
@@ -81,6 +74,9 @@ export async function POST(
         quantity: safeToNumber(item.quantity),
         unitPrice: safeToNumber(item.unitPrice),
       })),
+      btpInvoiceType: (invoice as any).btpInvoiceType as 'standard' | 'situation' | 'autoliquidation' | null,
+      situationNumber: (invoice as any).situationNumber ?? null,
+      referenceContract: (invoice as any).referenceContract ?? null,
     });
 
     if (readiness.status === 'blocked') {
@@ -157,6 +153,14 @@ export async function POST(
       paymentTerms: invoice.paymentTerms,
       latePenaltyRate: invoice.latePenaltyRate,
       recoveryIndemnity: invoice.recoveryIndemnity != null ? safeToNumber(invoice.recoveryIndemnity) : null,
+      btpInvoiceType: (invoice as any).btpInvoiceType as 'standard' | 'situation' | 'autoliquidation' | null ?? null,
+      retenueGarantieAmount: (invoice as any).retenueGarantieAmount != null ? safeToNumber((invoice as any).retenueGarantieAmount) : null,
+      situationNumber: (invoice as any).situationNumber ?? null,
+      referenceContract: (invoice as any).referenceContract ?? null,
+      previousCumulativeAmount: (invoice as any).previousCumulativeAmount != null ? safeToNumber((invoice as any).previousCumulativeAmount) : null,
+      previousInvoiceNumber: (invoice as any).previousInvoiceNumber ?? null,
+      codeService: (invoice as any).codeService ?? null,
+      buyerReference: (invoice as any).numeroEngagement ?? null,
     }, pdfBuffer);
 
     if (!facturx.success) {
@@ -215,6 +219,12 @@ export async function POST(
       }
     }
 
+    // Compute first reminder date from user's schedule (resets on issuance)
+    const reminderSchedule = parseReminderSchedule(issuer?.reminderSchedule);
+    const nextReminderAt = issuer?.reminderEnabled !== false && invoice.reminderEnabled
+      ? computeNextReminderDate(invoice.dueDate, 0, reminderSchedule)
+      : null;
+
     const updatedInvoice = await prisma.invoice.update({
       where: { id: invoice.id },
       data: {
@@ -227,6 +237,8 @@ export async function POST(
         facturxStatus: 'generated',
         facturxGeneratedAt: new Date(),
         facturxValidationErrors: [],
+        reminderCount: 0,
+        nextReminderAt,
       },
       include: { client: true, items: true },
     });

--- a/src/app/api/invoices/[invoiceId]/ppf-preflight/route.ts
+++ b/src/app/api/invoices/[invoiceId]/ppf-preflight/route.ts
@@ -69,6 +69,16 @@ export async function GET(
     }
   }
 
+  // ── B2G Chorus Pro routing fields ────────────────────────────────────────
+  if (invoice.transactionType === 'B2G') {
+    if (!(invoice as any).codeService) {
+      blockers.push('Code Service manquant — obligatoire pour le routage Chorus Pro vers une entité publique.');
+    }
+    if (!(invoice as any).numeroEngagement) {
+      warnings.push('N° Engagement (bon de commande) absent — peut entraîner un rejet ou un blocage de paiement par l\'entité publique.');
+    }
+  }
+
   // ── Factur-X PDF ─────────────────────────────────────────────────────────
   // null facturxPdfUrl is fine — submit-ppf regenerates in-memory when Cloudinary is not configured
   if (!invoice.facturxPdfUrl && invoice.facturxStatus !== 'generated') {

--- a/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
+++ b/src/app/api/invoices/[invoiceId]/submit-ppf/route.ts
@@ -72,6 +72,14 @@ export async function POST(
     ? (invoice.deliveryAddress as any)?.address ?? null
     : null;
 
+  const btpType = (invoice as any).btpInvoiceType as 'standard' | 'situation' | 'autoliquidation' | null ?? null;
+  const isB2G = invoice.transactionType === 'B2G';
+
+  // Chorus Pro "Cadre de Facturation": A2 = BTP sous-traitance B2G, A1 = marché public standard B2G
+  const cadreDeTravail = isB2G
+    ? (btpType === 'situation' || btpType === 'autoliquidation' ? 'A2' : 'A1')
+    : null;
+
   const xml = buildFacturxXml({
     invoiceNumber: invoice.invoiceNumber,
     invoiceDate: invoice.invoiceDate.toISOString(),
@@ -102,6 +110,17 @@ export async function POST(
     paymentTerms: invoice.paymentTerms,
     latePenaltyRate: invoice.latePenaltyRate,
     recoveryIndemnity: invoice.recoveryIndemnity != null ? Number(invoice.recoveryIndemnity) : null,
+    // BTP fields
+    btpInvoiceType: btpType,
+    retenueGarantieAmount: (invoice as any).retenueGarantieAmount != null ? Number((invoice as any).retenueGarantieAmount) : null,
+    situationNumber: (invoice as any).situationNumber ?? null,
+    referenceContract: (invoice as any).referenceContract ?? null,
+    previousCumulativeAmount: (invoice as any).previousCumulativeAmount != null ? Number((invoice as any).previousCumulativeAmount) : null,
+    previousInvoiceNumber: (invoice as any).previousInvoiceNumber ?? null,
+    // Chorus Pro routing
+    codeService: (invoice as any).codeService ?? null,
+    buyerReference: (invoice as any).numeroEngagement ?? null,
+    cadreDeTravail,
   });
 
   // Get Factur-X PDF: use stored URL if available, otherwise generate in-memory

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -6,6 +6,7 @@ import { authOptions } from '@/lib/auth-options';
 import { getLegalMentionsByFiscalRegime } from '@/lib/utils';
 import { evaluateInvoiceReadiness } from '@/domains/invoices/invoice-readiness';
 import { getUserPlan, getMonthlyInvoiceCount, FREE_INVOICE_LIMIT } from '@/lib/subscription';
+import { computeNextReminderDate, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
 
 const invoiceSchema = z.object({
   clientId: z.string(),
@@ -31,9 +32,21 @@ const invoiceSchema = z.object({
   clientContactName: z.string().optional(),
   clientEmail: z.string().optional(),
   clientPhone: z.string().optional(),
+  // BTP sub-contractor fields
+  btpInvoiceType: z.enum(['standard', 'situation', 'autoliquidation']).optional(),
+  retenueGarantieRate: z.number().min(0).max(100).optional(),
+  retenueGarantieAmount: z.number().min(0).optional(),
+  situationNumber: z.number().int().positive().optional(),
+  referenceContract: z.string().optional(),
+  previousCumulativeAmount: z.number().optional(),
+  cumulativeAmount: z.number().optional(),
+  previousInvoiceNumber: z.string().optional(),
+  // Chorus Pro B2G routing
+  codeService: z.string().optional(),
+  numeroEngagement: z.string().optional(),
 });
 
-export async function GET(req: NextRequest) {
+export async function GET(_req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -60,7 +73,7 @@ export async function POST(req: NextRequest) {
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { name: true, siret: true, tvaNumber: true, fiscalRegime: true, address: true, legalStatus: true, rcsNumber: true, shareCapital: true, apeCode: true, microEntrepreneurType: true },
+    select: { name: true, siret: true, tvaNumber: true, fiscalRegime: true, address: true, legalStatus: true, rcsNumber: true, shareCapital: true, apeCode: true, microEntrepreneurType: true, reminderEnabled: true, reminderSchedule: true },
   });
 
   // Completeness Check for Micro-Entrepreneurs
@@ -93,7 +106,15 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: validation.error.format() }, { status: 400 });
     }
 
-    const { clientId, invoiceDate, dueDate, transactionType, deliveryAddress, items, paymentTerms, latePenaltyRate, recoveryIndemnity, clientName, clientAddress, clientSiret, clientTvaNumber, clientLegalStatus, clientShareCapital, clientContactName, clientEmail, clientPhone } = validation.data;
+    const {
+      clientId, invoiceDate, dueDate, transactionType, deliveryAddress, items,
+      paymentTerms, latePenaltyRate, recoveryIndemnity,
+      clientName, clientAddress, clientSiret, clientTvaNumber, clientLegalStatus,
+      clientShareCapital, clientContactName, clientEmail, clientPhone,
+      btpInvoiceType, retenueGarantieRate, retenueGarantieAmount,
+      situationNumber, referenceContract, previousCumulativeAmount, cumulativeAmount,
+      previousInvoiceNumber, codeService, numeroEngagement,
+    } = validation.data;
 
     // Safe number parsing to prevent malformed currency values
     const safeToNumber = (value: any) => {
@@ -167,6 +188,9 @@ export async function POST(req: NextRequest) {
         quantity: safeToNumber(item.quantity),
         unitPrice: safeToNumber(item.unitPrice),
       })),
+      btpInvoiceType: btpInvoiceType ?? null,
+      situationNumber: situationNumber ?? null,
+      referenceContract: referenceContract ?? null,
     });
 
     const newInvoice = await prisma.invoice.create({
@@ -202,6 +226,24 @@ export async function POST(req: NextRequest) {
         latePenaltyRate: latePenaltyRate || "3 fois le taux d'intérêt légal",
         recoveryIndemnity: recoveryIndemnity || 40.0,
         legalMentions,
+        btpInvoiceType: btpInvoiceType ?? 'standard',
+        retenueGarantieRate: retenueGarantieRate != null ? retenueGarantieRate : null,
+        retenueGarantieAmount: retenueGarantieAmount != null ? retenueGarantieAmount : null,
+        situationNumber: situationNumber ?? null,
+        referenceContract: referenceContract ?? null,
+        previousCumulativeAmount: previousCumulativeAmount ?? null,
+        cumulativeAmount: cumulativeAmount ?? null,
+        previousInvoiceNumber: previousInvoiceNumber ?? null,
+        codeService: codeService ?? null,
+        numeroEngagement: numeroEngagement ?? null,
+        // Pre-schedule first reminder based on user's ladder
+        nextReminderAt: user?.reminderEnabled !== false
+          ? computeNextReminderDate(
+              new Date(dueDate),
+              0,
+              parseReminderSchedule(user?.reminderSchedule)
+            )
+          : null,
         items: {
           create: items.map(item => ({
             description: item.description,

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -6,7 +6,6 @@ import { authOptions } from '@/lib/auth-options';
 import { getLegalMentionsByFiscalRegime } from '@/lib/utils';
 import { evaluateInvoiceReadiness } from '@/domains/invoices/invoice-readiness';
 import { getUserPlan, getMonthlyInvoiceCount, FREE_INVOICE_LIMIT } from '@/lib/subscription';
-import { computeNextReminderDate, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
 
 const invoiceSchema = z.object({
   clientId: z.string(),
@@ -73,7 +72,7 @@ export async function POST(req: NextRequest) {
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { name: true, siret: true, tvaNumber: true, fiscalRegime: true, address: true, legalStatus: true, rcsNumber: true, shareCapital: true, apeCode: true, microEntrepreneurType: true, reminderEnabled: true, reminderSchedule: true },
+    select: { name: true, siret: true, tvaNumber: true, fiscalRegime: true, address: true, legalStatus: true, rcsNumber: true, shareCapital: true, apeCode: true, microEntrepreneurType: true },
   });
 
   // Completeness Check for Micro-Entrepreneurs
@@ -236,14 +235,6 @@ export async function POST(req: NextRequest) {
         previousInvoiceNumber: previousInvoiceNumber ?? null,
         codeService: codeService ?? null,
         numeroEngagement: numeroEngagement ?? null,
-        // Pre-schedule first reminder based on user's ladder
-        nextReminderAt: user?.reminderEnabled !== false
-          ? computeNextReminderDate(
-              new Date(dueDate),
-              0,
-              parseReminderSchedule(user?.reminderSchedule)
-            )
-          : null,
         items: {
           create: items.map(item => ({
             description: item.description,

--- a/src/app/components/InvoicePdf.tsx
+++ b/src/app/components/InvoicePdf.tsx
@@ -2,9 +2,6 @@
 import React from 'react';
 import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
 
-// Register a font to support special characters if needed
-// Font.register({ family: 'Roboto', src: '/fonts/Roboto-Regular.ttf' });
-
 const styles = StyleSheet.create({
   page: {
     flexDirection: 'column',
@@ -24,6 +21,10 @@ const styles = StyleSheet.create({
     color: '#2563eb',
     marginBottom: 5,
   },
+  headerSubtitle: {
+    fontSize: 10,
+    color: '#666',
+  },
   invoiceDetails: {
     textAlign: 'right',
   },
@@ -37,6 +38,52 @@ const styles = StyleSheet.create({
     fontSize: 10,
     color: '#666',
   },
+  // BTP situation banner
+  situationBanner: {
+    backgroundColor: '#eff6ff',
+    borderRadius: 5,
+    borderWidth: 1,
+    borderColor: '#2563eb',
+    borderStyle: 'solid',
+    padding: 12,
+    marginBottom: 20,
+  },
+  situationBannerTitle: {
+    fontSize: 11,
+    fontWeight: 'bold',
+    color: '#1d4ed8',
+    marginBottom: 6,
+  },
+  situationBannerRow: {
+    flexDirection: 'row',
+    marginBottom: 3,
+  },
+  situationBannerLabel: {
+    fontSize: 9,
+    color: '#374151',
+    width: '40%',
+  },
+  situationBannerValue: {
+    fontSize: 9,
+    fontWeight: 'bold',
+    color: '#111827',
+    width: '60%',
+  },
+  // Autoliquidation banner
+  autoliqBanner: {
+    backgroundColor: '#fef9c3',
+    borderRadius: 5,
+    borderWidth: 1,
+    borderColor: '#ca8a04',
+    borderStyle: 'solid',
+    padding: 10,
+    marginBottom: 20,
+  },
+  autoliqBannerText: {
+    fontSize: 9,
+    color: '#713f12',
+    lineHeight: 1.5,
+  },
   partiesSection: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -49,19 +96,19 @@ const styles = StyleSheet.create({
     borderRadius: 5,
   },
   partyTitle: {
-    fontSize: 14,
+    fontSize: 11,
     fontWeight: 'bold',
     marginBottom: 10,
     color: '#374151',
     textTransform: 'uppercase',
   },
   partyText: {
-    fontSize: 10,
+    fontSize: 9,
     marginBottom: 3,
     color: '#4b5563',
   },
   partyName: {
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: 'bold',
     marginBottom: 5,
     color: '#111827',
@@ -70,14 +117,14 @@ const styles = StyleSheet.create({
     marginBottom: 30,
   },
   sectionTitle: {
-    fontSize: 16,
+    fontSize: 13,
     fontWeight: 'bold',
-    marginBottom: 15,
+    marginBottom: 12,
     color: '#374151',
     borderBottomWidth: 2,
     borderBottomColor: '#2563eb',
     borderBottomStyle: 'solid',
-    paddingBottom: 5,
+    paddingBottom: 4,
   },
   table: {
     width: 'auto',
@@ -89,7 +136,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0,
   },
   tableRow: {
-    margin: 'auto',
     flexDirection: 'row',
   },
   tableColHeader: {
@@ -99,7 +145,7 @@ const styles = StyleSheet.create({
     borderLeftWidth: 0,
     borderTopWidth: 0,
     backgroundColor: '#f3f4f6',
-    padding: 8,
+    padding: 7,
   },
   tableCol: {
     borderStyle: 'solid',
@@ -107,25 +153,30 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderLeftWidth: 0,
     borderTopWidth: 0,
-    padding: 8,
+    padding: 7,
   },
-  tableColDesc: { width: '40%' },
-  tableColQty: { width: '12%' },
+  tableColDesc:  { width: '40%' },
+  tableColQty:   { width: '12%' },
   tableColPrice: { width: '16%' },
-  tableColTva: { width: '12%' },
+  tableColTva:   { width: '12%' },
   tableColTotal: { width: '20%' },
   tableCellHeader: {
-    fontSize: 11,
+    fontSize: 10,
     fontWeight: 'bold',
     color: '#374151',
   },
   tableCell: {
-    fontSize: 10,
+    fontSize: 9,
     color: '#4b5563',
   },
   tableCellRight: {
-    fontSize: 10,
+    fontSize: 9,
     color: '#4b5563',
+    textAlign: 'right',
+  },
+  tableCellMuted: {
+    fontSize: 9,
+    color: '#9ca3af',
     textAlign: 'right',
   },
   totalSection: {
@@ -133,7 +184,7 @@ const styles = StyleSheet.create({
     marginBottom: 30,
   },
   totalBox: {
-    width: '50%',
+    width: '52%',
     padding: 15,
     backgroundColor: '#eff6ff',
     borderRadius: 5,
@@ -145,206 +196,229 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 8,
+    marginBottom: 7,
   },
   totalLabel: {
-    fontSize: 12,
+    fontSize: 10,
+    color: '#374151',
+  },
+  totalLabelBold: {
+    fontSize: 11,
     fontWeight: 'bold',
     color: '#374151',
   },
   totalAmount: {
-    fontSize: 14,
+    fontSize: 11,
     fontWeight: 'bold',
     color: '#2563eb',
   },
   totalAmountFinal: {
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: 'bold',
     color: '#2563eb',
   },
+  totalAmountDeduction: {
+    fontSize: 10,
+    color: '#b45309',
+  },
+  totalDivider: {
+    borderTopWidth: 1,
+    borderTopColor: '#bfdbfe',
+    borderTopStyle: 'solid',
+    marginBottom: 7,
+    marginTop: 2,
+  },
   bankSection: {
-    marginBottom: 20,
-    padding: 15,
+    marginBottom: 15,
+    padding: 12,
     backgroundColor: '#f9fafb',
     borderRadius: 5,
   },
   paymentTermsSection: {
-    marginBottom: 20,
-    padding: 15,
+    marginBottom: 15,
+    padding: 12,
     backgroundColor: '#f9fafb',
     borderRadius: 5,
   },
-  paymentTermsTitle: {
-    fontSize: 14,
+  sectionSubTitle: {
+    fontSize: 11,
     fontWeight: 'bold',
-    marginBottom: 10,
+    marginBottom: 8,
     color: '#374151',
   },
   paymentTermsText: {
-    fontSize: 10,
+    fontSize: 9,
     lineHeight: 1.5,
     color: '#4b5563',
-    marginBottom: 5,
+    marginBottom: 4,
   },
   legalMentionsSection: {
-    marginTop: 30,
-    paddingTop: 20,
+    marginTop: 20,
+    paddingTop: 15,
     borderTopWidth: 1,
     borderTopColor: '#e5e7eb',
     borderTopStyle: 'solid',
   },
   legalMentionsText: {
-    fontSize: 8,
-    lineHeight: 1.4,
+    fontSize: 7.5,
+    lineHeight: 1.5,
     color: '#6b7280',
   },
   footer: {
-    fontSize: 8,
-    marginTop: 30,
+    fontSize: 7.5,
+    marginTop: 20,
     textAlign: 'center',
     color: '#9ca3af',
     borderTopWidth: 1,
     borderTopColor: '#e5e7eb',
     borderTopStyle: 'solid',
-    paddingTop: 15,
+    paddingTop: 12,
   },
 });
 
-const InvoicePdf = ({ invoice }: any) => {
-  // Custom PDF-safe French currency formatter (bypasses toLocaleString issues)
-  const formatCurrency = (value: any) => {
-    // Handle null, undefined, empty values
-    if (value === null || value === undefined || value === '') {
-      return '0,00 €';
-    }
+const safeNum = (v: unknown): number => {
+  if (v === null || v === undefined || v === '') return 0;
+  const n = Number(v);
+  return isNaN(n) ? 0 : n;
+};
 
-    const numValue = Number(value);
-    if (isNaN(numValue)) {
-      console.warn('Invalid currency value for PDF:', value);
-      return '0,00 €';
-    }
-    
-    // Custom formatting to avoid toLocaleString issues
-    const absoluteValue = Math.abs(numValue);
-    const [integer, decimal = '00'] = absoluteValue.toFixed(2).split('.');
-    
-    // Add thousands separators with regular spaces (not non-breaking spaces)
-    const formattedInteger = integer.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
-    
-    // Handle negative numbers
-    const sign = numValue < 0 ? '-' : '';
-    
-    // Use French decimal comma format
-    const result = `${sign}${formattedInteger},${decimal} €`;
-    
-    console.log('InvoicePDF formatCurrency - Input:', value, 'Output:', result);
-    return result;
-  };
+const fmt = (v: number): string => {
+  const abs = Math.abs(v);
+  const [int, dec = '00'] = abs.toFixed(2).split('.');
+  const intFmt = int.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+  return `${v < 0 ? '-' : ''}${intFmt},${dec} €`;
+};
 
-  // Helper function to safely convert any value to number
-  const safeToNumber = (value: any) => {
-    if (value === null || value === undefined || value === '') {
-      return 0;
-    }
-    
-    let cleanValue = value;
-    if (typeof value === 'string') {
-      console.log('InvoicePDF safeToNumber - Original value:', value);
-      
-      // Handle multiple slash patterns
-      // Pattern: "8/000,00" -> "8000.00"
-      cleanValue = cleanValue.replace(/(\d+)\/(\d{3}),(\d{2})/g, '$1$2.$3');
-      // Pattern: "8/000" -> "8000"  
-      cleanValue = cleanValue.replace(/(\d+)\/(\d{3})/g, '$1$2');
-      // Pattern: "1 8/000,00" -> "18000.00" (space before number)
-      cleanValue = cleanValue.replace(/(\d+)\s+(\d+)\/(\d{3}),(\d{2})/g, '$1$2$3.$4');
-      // Pattern: "1 8/000" -> "18000"
-      cleanValue = cleanValue.replace(/(\d+)\s+(\d+)\/(\d{3})/g, '$1$2$3');
-      
-      // Convert French decimal comma to dot for parsing
-      cleanValue = cleanValue.replace(',', '.');
-      // Remove any remaining non-numeric characters except dots and minus
-      cleanValue = cleanValue.replace(/[^0-9.-]/g, '');
-      
-      console.log('InvoicePDF safeToNumber - Cleaned value:', cleanValue);
-    }
-    
-    const numValue = Number(cleanValue || 0);
-    const result = isNaN(numValue) ? 0 : numValue;
-    console.log('InvoicePDF safeToNumber - Final result:', result);
-    return result;
-  };
+const fmtDate = (d: string | Date | undefined): string => {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('fr-FR');
+};
 
-  const totalTVA = invoice.items?.reduce((acc: number, item: any) => {
-    const quantity = safeToNumber(item.quantity || 1);
-    const unitPrice = safeToNumber(item.unitPrice);
-    const tvaRate = safeToNumber(item.tvaRate || 0);
-    const itemTotal = quantity * unitPrice;
-    return acc + itemTotal * tvaRate;
-  }, 0) || 0;
+const InvoicePdf = ({ invoice }: { invoice: any }) => {
+  const btpType: 'standard' | 'situation' | 'autoliquidation' | null =
+    invoice.btpInvoiceType ?? null;
+  const isAutoliq  = btpType === 'autoliquidation';
+  const isSituation = btpType === 'situation';
+  const retenueAmount = safeNum(invoice.retenueGarantieAmount);
+  const retenueRate   = safeNum(invoice.retenueGarantieRate);
 
-  const totalHT = safeToNumber(invoice.totalAmount);
-  const totalTTC = totalHT + totalTVA;
+  const lineHT = (invoice.items ?? []).reduce((acc: number, item: any) => {
+    return acc + safeNum(item.quantity || 1) * safeNum(item.unitPrice);
+  }, 0);
+
+  // For autoliquidation invoices TVA is always 0
+  const totalTVA = isAutoliq
+    ? 0
+    : (invoice.items ?? []).reduce((acc: number, item: any) => {
+        const qty  = safeNum(item.quantity || 1);
+        const pu   = safeNum(item.unitPrice);
+        const rate = safeNum(item.tvaRate || 0);
+        return acc + qty * pu * rate;
+      }, 0);
+
+  const totalTTC    = lineHT + totalTVA;
+  const netAPayer   = totalTTC - retenueAmount;
 
   return (
     <Document>
       <Page size="A4" style={styles.page}>
-        {/* Header with Invoice Title and Details */}
+
+        {/* ── Header ────────────────────────────────────────── */}
         <View style={styles.headerSection}>
           <View>
             <Text style={styles.header}>FACTURE</Text>
-            <Text style={styles.invoiceDate}>
-              Facture professionnelle
+            <Text style={styles.headerSubtitle}>
+              {isAutoliq   ? 'Autoliquidation TVA — art. 283, 2 nonies CGI'
+                : isSituation ? `Facture de situation n° ${invoice.situationNumber ?? '—'}`
+                : 'Facture professionnelle'}
             </Text>
           </View>
           <View style={styles.invoiceDetails}>
-            <Text style={styles.invoiceNumber}>N° {invoice.invoiceNumber}</Text>
-            <Text style={styles.invoiceDate}>
-              Date : {new Date(invoice.invoiceDate).toLocaleDateString('fr-FR')}
-            </Text>
-            <Text style={styles.invoiceDate}>
-              Échéance : {new Date(invoice.dueDate).toLocaleDateString('fr-FR')}
-            </Text>
+            <Text style={styles.invoiceNumber}>N° {invoice.invoiceNumber}</Text>
+            <Text style={styles.invoiceDate}>Date : {fmtDate(invoice.invoiceDate)}</Text>
+            <Text style={styles.invoiceDate}>Échéance : {fmtDate(invoice.dueDate)}</Text>
           </View>
         </View>
 
-        {/* Parties Section */}
+        {/* ── Situation banner ──────────────────────────────── */}
+        {isSituation && (
+          <View style={styles.situationBanner}>
+            <Text style={styles.situationBannerTitle}>Détails de la situation de travaux</Text>
+            {invoice.referenceContract && (
+              <View style={styles.situationBannerRow}>
+                <Text style={styles.situationBannerLabel}>Référence contrat :</Text>
+                <Text style={styles.situationBannerValue}>{invoice.referenceContract}</Text>
+              </View>
+            )}
+            <View style={styles.situationBannerRow}>
+              <Text style={styles.situationBannerLabel}>N° de situation :</Text>
+              <Text style={styles.situationBannerValue}>{invoice.situationNumber ?? '—'}</Text>
+            </View>
+            {safeNum(invoice.previousCumulativeAmount) > 0 && (
+              <View style={styles.situationBannerRow}>
+                <Text style={styles.situationBannerLabel}>Cumul précédent :</Text>
+                <Text style={styles.situationBannerValue}>
+                  {fmt(safeNum(invoice.previousCumulativeAmount))}
+                </Text>
+              </View>
+            )}
+            <View style={styles.situationBannerRow}>
+              <Text style={styles.situationBannerLabel}>Montant de cette situation :</Text>
+              <Text style={styles.situationBannerValue}>{fmt(lineHT)}</Text>
+            </View>
+          </View>
+        )}
+
+        {/* ── Autoliquidation banner ────────────────────────── */}
+        {isAutoliq && (
+          <View style={styles.autoliqBanner}>
+            <Text style={styles.autoliqBannerText}>
+              {'TVA autoliquidée par le preneur assujetti — Article 283, 2 nonies du CGI\n'}
+              {'(Sous-traitance dans le cadre de travaux de construction pour le compte d\'un donneur d\'ordre assujetti)'}
+            </Text>
+          </View>
+        )}
+
+        {/* ── Parties ───────────────────────────────────────── */}
         <View style={styles.partiesSection}>
           <View style={styles.partyBox}>
             <Text style={styles.partyTitle}>Émetteur</Text>
-            <Text style={styles.partyName}>{invoice.issuerName || 'Non fourni'}</Text>
-            {invoice.issuerAddress && <Text style={styles.partyText}>Adresse : {invoice.issuerAddress}</Text>}
-            {invoice.issuerSiret && <Text style={styles.partyText}>SIRET : {invoice.issuerSiret}</Text>}
-            {invoice.issuerTva && <Text style={styles.partyText}>N° TVA : {invoice.issuerTva}</Text>}
-            {invoice.issuerRcs && <Text style={styles.partyText}>RCS : {invoice.issuerRcs}</Text>}
+            <Text style={styles.partyName}>{invoice.issuerName || '—'}</Text>
+            {invoice.issuerAddress     && <Text style={styles.partyText}>Adresse : {invoice.issuerAddress}</Text>}
+            {invoice.issuerSiret       && <Text style={styles.partyText}>SIRET : {invoice.issuerSiret}</Text>}
+            {invoice.issuerTva         && <Text style={styles.partyText}>N° TVA : {invoice.issuerTva}</Text>}
+            {invoice.issuerRcs         && <Text style={styles.partyText}>RCS : {invoice.issuerRcs}</Text>}
             {invoice.issuerLegalStatus && <Text style={styles.partyText}>Statut : {invoice.issuerLegalStatus}</Text>}
             {invoice.issuerShareCapital && <Text style={styles.partyText}>Capital : {invoice.issuerShareCapital}</Text>}
-            {invoice.issuerApeCode && <Text style={styles.partyText}>Code APE : {invoice.issuerApeCode}</Text>}
+            {invoice.issuerApeCode     && <Text style={styles.partyText}>Code APE : {invoice.issuerApeCode}</Text>}
           </View>
-          
+
           <View style={styles.partyBox}>
             <Text style={styles.partyTitle}>Client</Text>
             <Text style={styles.partyName}>
-              {invoice.client?.name || invoice.clientName || 'Non fourni'}
+              {invoice.client?.name || invoice.clientName || '—'}
             </Text>
             {(invoice.client?.email || invoice.clientEmail) && (
               <Text style={styles.partyText}>Email : {invoice.client?.email || invoice.clientEmail}</Text>
             )}
-            {invoice.clientAddress && <Text style={styles.partyText}>Adresse : {invoice.clientAddress}</Text>}
-            {invoice.clientSiret && <Text style={styles.partyText}>SIRET : {invoice.clientSiret}</Text>}
-            {invoice.clientTvaNumber && <Text style={styles.partyText}>N° TVA : {invoice.clientTvaNumber}</Text>}
-            {invoice.clientLegalStatus && <Text style={styles.partyText}>Statut : {invoice.clientLegalStatus}</Text>}
-            {invoice.clientShareCapital && <Text style={styles.partyText}>Capital : {invoice.clientShareCapital}</Text>}
-            {invoice.clientContactName && <Text style={styles.partyText}>Contact : {invoice.clientContactName}</Text>}
-            {invoice.clientPhone && <Text style={styles.partyText}>Téléphone : {invoice.clientPhone}</Text>}
+            {(invoice.clientAddress || invoice.client?.address) && (
+              <Text style={styles.partyText}>Adresse : {invoice.clientAddress || invoice.client?.address}</Text>
+            )}
+            {(invoice.clientSiret || invoice.client?.siret) && (
+              <Text style={styles.partyText}>SIRET : {invoice.clientSiret || invoice.client?.siret}</Text>
+            )}
+            {(invoice.clientTvaNumber || invoice.client?.tvaNumber) && (
+              <Text style={styles.partyText}>N° TVA : {invoice.clientTvaNumber || invoice.client?.tvaNumber}</Text>
+            )}
           </View>
         </View>
 
-        {/* Services Section */}
+        {/* ── Line items ────────────────────────────────────── */}
         <View style={styles.servicesSection}>
           <Text style={styles.sectionTitle}>Prestations et services</Text>
-          
+
           <View style={styles.table}>
+            {/* Header row */}
             <View style={styles.tableRow}>
               <View style={[styles.tableColHeader, styles.tableColDesc]}>
                 <Text style={styles.tableCellHeader}>Description</Text>
@@ -362,113 +436,144 @@ const InvoicePdf = ({ invoice }: any) => {
                 <Text style={styles.tableCellHeader}>Total HT</Text>
               </View>
             </View>
-            
-            {invoice.items?.map((item: any, index: number) => (
-              <View style={styles.tableRow} key={index}>
-                <View style={[styles.tableCol, styles.tableColDesc]}>
-                  <Text style={styles.tableCell}>{item.description || 'Service'}</Text>
+
+            {/* Data rows */}
+            {(invoice.items ?? []).map((item: any, idx: number) => {
+              const qty   = safeNum(item.quantity || 1);
+              const pu    = safeNum(item.unitPrice);
+              const rate  = safeNum(item.tvaRate || 0);
+              const total = qty * pu;
+              return (
+                <View style={styles.tableRow} key={idx}>
+                  <View style={[styles.tableCol, styles.tableColDesc]}>
+                    <Text style={styles.tableCell}>{item.description || 'Prestation'}</Text>
+                  </View>
+                  <View style={[styles.tableCol, styles.tableColQty]}>
+                    <Text style={styles.tableCellRight}>{item.quantity ?? 1}</Text>
+                  </View>
+                  <View style={[styles.tableCol, styles.tableColPrice]}>
+                    <Text style={styles.tableCellRight}>{fmt(pu)}</Text>
+                  </View>
+                  <View style={[styles.tableCol, styles.tableColTva]}>
+                    {isAutoliq
+                      ? <Text style={styles.tableCellMuted}>Autoliq.</Text>
+                      : <Text style={styles.tableCellRight}>{(rate * 100).toFixed(0)} %</Text>}
+                  </View>
+                  <View style={[styles.tableCol, styles.tableColTotal]}>
+                    <Text style={styles.tableCellRight}>{fmt(total)}</Text>
+                  </View>
                 </View>
-                <View style={[styles.tableCol, styles.tableColQty]}>
-                  <Text style={styles.tableCellRight}>{item.quantity || 1}</Text>
-                </View>
-                <View style={[styles.tableCol, styles.tableColPrice]}>
-                  <Text style={styles.tableCellRight}>
-                    {formatCurrency(safeToNumber(item.unitPrice))}
-                  </Text>
-                </View>
-                <View style={[styles.tableCol, styles.tableColTva]}>
-                  <Text style={styles.tableCellRight}>
-                    {(safeToNumber(item.tvaRate || 0) * 100).toFixed(0)}%
-                  </Text>
-                </View>
-                <View style={[styles.tableCol, styles.tableColTotal]}>
-                  <Text style={styles.tableCellRight}>
-                    {formatCurrency(safeToNumber(item.quantity || 1) * safeToNumber(item.unitPrice))}
-                  </Text>
-                </View>
-              </View>
-            ))}
+              );
+            })}
           </View>
         </View>
 
-        {/* Total Section */}
+        {/* ── Totals ────────────────────────────────────────── */}
         <View style={styles.totalSection}>
           <View style={styles.totalBox}>
             <View style={styles.totalRow}>
               <Text style={styles.totalLabel}>Total HT :</Text>
-              <Text style={styles.totalAmount}>
-                {formatCurrency(totalHT)}
-              </Text>
+              <Text style={styles.totalAmount}>{fmt(lineHT)}</Text>
             </View>
+
+            {isAutoliq ? (
+              <View style={styles.totalRow}>
+                <Text style={styles.totalLabel}>TVA (autoliquidée) :</Text>
+                <Text style={[styles.totalAmount, { color: '#b45309' }]}>0,00 €</Text>
+              </View>
+            ) : (
+              <View style={styles.totalRow}>
+                <Text style={styles.totalLabel}>Total TVA :</Text>
+                <Text style={styles.totalAmount}>{fmt(totalTVA)}</Text>
+              </View>
+            )}
+
+            <View style={styles.totalDivider} />
+
             <View style={styles.totalRow}>
-              <Text style={styles.totalLabel}>Total TVA :</Text>
-              <Text style={styles.totalAmount}>
-                {formatCurrency(totalTVA)}
+              <Text style={styles.totalLabelBold}>Total TTC :</Text>
+              <Text style={retenueAmount > 0 ? styles.totalAmount : styles.totalAmountFinal}>
+                {fmt(totalTTC)}
               </Text>
             </View>
-            <View style={[styles.totalRow, { borderTopWidth: 1, borderTopColor: '#2563eb', paddingTop: 8 }]}>
-              <Text style={styles.totalLabel}>Total TTC :</Text>
-              <Text style={styles.totalAmountFinal}>
-                {formatCurrency(totalTTC)}
-              </Text>
-            </View>
+
+            {retenueAmount > 0 && (
+              <>
+                <View style={styles.totalRow}>
+                  <Text style={styles.totalLabel}>
+                    Retenue de garantie ({retenueRate > 0 ? `${(retenueRate * 100).toFixed(0)} %` : 'forfait'}) :
+                  </Text>
+                  <Text style={styles.totalAmountDeduction}>- {fmt(retenueAmount)}</Text>
+                </View>
+                <View style={styles.totalDivider} />
+                <View style={styles.totalRow}>
+                  <Text style={styles.totalLabelBold}>Net à payer :</Text>
+                  <Text style={styles.totalAmountFinal}>{fmt(netAPayer)}</Text>
+                </View>
+              </>
+            )}
           </View>
         </View>
 
-        {/* Bank Details Section */}
+        {/* ── Bank details ──────────────────────────────────── */}
         {(invoice.issuerIban || invoice.issuerBic) && (
           <View style={styles.bankSection}>
-            <Text style={styles.paymentTermsTitle}>Coordonnées bancaires</Text>
-            {invoice.issuerIban && (
-              <Text style={styles.paymentTermsText}>IBAN : {invoice.issuerIban}</Text>
-            )}
-            {invoice.issuerBic && (
-              <Text style={styles.paymentTermsText}>BIC : {invoice.issuerBic}</Text>
-            )}
-            {invoice.issuerBankName && (
-              <Text style={styles.paymentTermsText}>Banque : {invoice.issuerBankName}</Text>
-            )}
+            <Text style={styles.sectionSubTitle}>Coordonnées bancaires</Text>
+            {invoice.issuerIban     && <Text style={styles.paymentTermsText}>IBAN : {invoice.issuerIban}</Text>}
+            {invoice.issuerBic      && <Text style={styles.paymentTermsText}>BIC : {invoice.issuerBic}</Text>}
+            {invoice.issuerBankName && <Text style={styles.paymentTermsText}>Banque : {invoice.issuerBankName}</Text>}
           </View>
         )}
 
-        {/* Payment Terms Section */}
+        {/* ── Payment conditions ────────────────────────────── */}
         <View style={styles.paymentTermsSection}>
-          <Text style={styles.paymentTermsTitle}>Conditions de paiement</Text>
-          <Text style={styles.paymentTermsText}>
-            Date d'échéance : {new Date(invoice.dueDate).toLocaleDateString('fr-FR')}
-          </Text>
+          <Text style={styles.sectionSubTitle}>Conditions de paiement</Text>
+          <Text style={styles.paymentTermsText}>Date d'échéance : {fmtDate(invoice.dueDate)}</Text>
           {invoice.paymentTerms && (
-            <Text style={styles.paymentTermsText}>
-              Délai de règlement : {invoice.paymentTerms}
-            </Text>
+            <Text style={styles.paymentTermsText}>Délai de règlement : {invoice.paymentTerms}</Text>
           )}
           {invoice.latePenaltyRate && (
             <Text style={styles.paymentTermsText}>
               Taux de pénalité de retard : {invoice.latePenaltyRate}
             </Text>
           )}
-          {invoice.recoveryIndemnity && (
+          {invoice.recoveryIndemnity && safeNum(invoice.recoveryIndemnity) > 0 && (
             <Text style={styles.paymentTermsText}>
-              Indemnité forfaitaire de recouvrement : {formatCurrency(invoice.recoveryIndemnity)}
+              Indemnité forfaitaire de recouvrement : {fmt(safeNum(invoice.recoveryIndemnity))}
+            </Text>
+          )}
+          {retenueAmount > 0 && (
+            <Text style={styles.paymentTermsText}>
+              Retenue de garantie libérable dans les conditions de l'article 2318 du Code civil.
             </Text>
           )}
         </View>
 
-        {/* Legal Mentions Section */}
+        {/* ── Legal mentions ────────────────────────────────── */}
         <View style={styles.legalMentionsSection}>
           <Text style={styles.sectionTitle}>Mentions légales</Text>
           <Text style={styles.legalMentionsText}>
-            {invoice.legalMentions ||
-            `Paiement à réception de facture. Aucun escompte consenti pour paiement anticipé.\n\nEn cas de retard de paiement, des pénalités de retard au taux de 3 fois le taux d'intérêt légal ainsi qu'une indemnité forfaitaire de recouvrement de 40€ seront automatiquement appliquées.\n\n${totalTVA === 0 ? 'TVA non applicable, art. 293 B du CGI.\n\n' : ''}Facture émise conformément à la réglementation française en vigueur.`}
+            {invoice.legalMentions || [
+              'Paiement à réception de facture. Aucun escompte consenti pour paiement anticipé.',
+              '',
+              "En cas de retard de paiement, des pénalités de retard au taux de 3 fois le taux d'intérêt légal ainsi qu'une indemnité forfaitaire de recouvrement de 40 € seront automatiquement appliquées (art. L441-10 du Code de commerce).",
+              '',
+              isAutoliq
+                ? "Opération soumise à l'autoliquidation de la TVA — le preneur est redevable de la TVA en lieu et place du prestataire (art. 283, 2 nonies du CGI). Facture établie hors TVA."
+                : totalTVA === 0
+                  ? 'TVA non applicable, art. 293 B du CGI.'
+                  : null,
+              '',
+              'Facture émise en conformité avec la réglementation française de facturation électronique (EN 16931 — Factur-X).',
+            ].filter(Boolean).join('\n')}
           </Text>
         </View>
 
-        {/* Footer */}
+        {/* ── Footer ────────────────────────────────────────── */}
         <Text style={styles.footer}>
-          Document généré par InvoiceOps - Plateforme de facturation professionnelle
-          {'\n'}
-          {invoice.issuerName} - {invoice.issuerAddress || 'Adresse non fournie'}
+          {`Document généré par InvoiceOps — ${invoice.issuerName || ''}${invoice.issuerAddress ? ` — ${invoice.issuerAddress}` : ''}`}
         </Text>
+
       </Page>
     </Document>
   );

--- a/src/app/dashboard/create-invoice/page.tsx
+++ b/src/app/dashboard/create-invoice/page.tsx
@@ -35,11 +35,21 @@ interface FormData {
   clientContactName?: string;
   clientEmail?: string;
   clientPhone?: string;
+  // BTP sub-contractor fields
+  btpInvoiceType: 'standard' | 'situation' | 'autoliquidation';
+  retenueGarantieEnabled: boolean;
+  retenueGarantieRate: number;
+  situationNumber: string;
+  referenceContract: string;
+  previousCumulativeAmount: string;
+  previousInvoiceNumber: string;
+  // Chorus Pro B2G routing
+  codeService: string;
+  numeroEngagement: string;
 }
 
 const invoiceSchema = z.object({
   clientId: z.string().min(1, 'Client is required'),
-
   invoiceDate: z.string().min(1, 'Invoice date is required'),
   dueDate: z.string().min(1, 'Due date is required'),
   items: z.array(z.object({
@@ -62,6 +72,12 @@ const invoiceSchema = z.object({
   clientContactName: z.string().optional(),
   clientEmail: z.string().optional(),
   clientPhone: z.string().optional(),
+  btpInvoiceType: z.enum(['standard', 'situation', 'autoliquidation']).optional(),
+  retenueGarantieRate: z.number().min(0).max(100).optional(),
+  retenueGarantieAmount: z.number().min(0).optional(),
+  situationNumber: z.number().int().positive().optional(),
+  referenceContract: z.string().optional(),
+  previousCumulativeAmount: z.number().optional(),
 });
 
 export default function CreateInvoicePage() {
@@ -78,11 +94,19 @@ export default function CreateInvoicePage() {
     paymentTerms: 'Paiement à 30 jours fin de mois',
     latePenaltyRate: "3 fois le taux d'intérêt légal",
     recoveryIndemnity: 40,
+    btpInvoiceType: 'standard',
+    retenueGarantieEnabled: false,
+    retenueGarantieRate: 5,
+    situationNumber: '',
+    referenceContract: '',
+    previousCumulativeAmount: '',
+    previousInvoiceNumber: '',
+    codeService: '',
+    numeroEngagement: '',
   });
   const { clients, mutate: refetchClients } = useApiClients();
   const { quota } = useQuota();
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const [loading] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -93,7 +117,8 @@ export default function CreateInvoicePage() {
   const [extractionSource, setExtractionSource] = useState<string | null>(null);
   const [suggestNewClient, setSuggestNewClient] = useState<{ name: string; address?: string; email?: string; siret?: string } | null>(null);
   const [creatingClient, setCreatingClient] = useState(false);
-  const [siretCheck, setSiretCheck] = useState<{ loading: boolean; result: { valid: boolean; active: boolean; companyName: string | null; error?: string } | null }>({ loading: false, result: null });
+  const [siretCheck, setSiretCheck] = useState<{ loading: boolean; result: { valid: boolean; active: boolean; companyName: string | null; isPublicEntity?: boolean; error?: string } | null }>({ loading: false, result: null });
+  const [isPublicClient, setIsPublicClient] = useState(false);
 
   const handleDocumentUpload = async (file: File) => {
     setExtracting(true);
@@ -177,6 +202,7 @@ export default function CreateInvoicePage() {
       const res = await fetch(`/api/siret?siret=${encodeURIComponent(clientSiret)}`);
       const data = await res.json();
       setSiretCheck({ loading: false, result: data });
+      setIsPublicClient(data.isPublicEntity === true);
       if (data.valid && data.active && formData.clientId) {
         await fetch('/api/siret', {
           method: 'POST',
@@ -195,6 +221,7 @@ export default function CreateInvoicePage() {
     if (name === 'clientId') {
       const selectedClient = clients.find((client: Client) => client.id === value);
       setSiretCheck({ loading: false, result: null });
+      setIsPublicClient(false);
       setFormData({
         ...formData,
         clientId: value,
@@ -257,10 +284,29 @@ export default function CreateInvoicePage() {
 
     setIsSubmitting(true);
     try {
+      // Compute retenue amount from rate when enabled
+      const subtotal = formData.items.reduce((t, i) => t + i.quantity * i.unitPrice, 0);
+      const retenueAmount = formData.retenueGarantieEnabled
+        ? parseFloat((subtotal * formData.retenueGarantieRate / 100).toFixed(2))
+        : undefined;
+
+      const payload = {
+        ...result.data,
+        btpInvoiceType: formData.btpInvoiceType !== 'standard' ? formData.btpInvoiceType : undefined,
+        retenueGarantieRate: formData.retenueGarantieEnabled ? formData.retenueGarantieRate : undefined,
+        retenueGarantieAmount: retenueAmount,
+        situationNumber: formData.situationNumber ? parseInt(formData.situationNumber) : undefined,
+        referenceContract: formData.referenceContract || undefined,
+        previousCumulativeAmount: formData.previousCumulativeAmount ? parseFloat(formData.previousCumulativeAmount) : undefined,
+        previousInvoiceNumber: formData.previousInvoiceNumber || undefined,
+        codeService: formData.codeService || undefined,
+        numeroEngagement: formData.numeroEngagement || undefined,
+      };
+
       const response = await fetch('/api/invoices', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(result.data),
+        body: JSON.stringify(payload),
       });
 
       if (!response.ok) {
@@ -283,33 +329,18 @@ export default function CreateInvoicePage() {
     }
   };
 
-  // Helper functions for enhanced UX with proper French fiscal regime handling
-  // For Micro-Entrepreneurs, TVA is always exempt
-  const isTvaExempt = () => {
-    return true; // Always true for Micro-Entrepreneurs
+  const calculateSubtotal = () =>
+    formData.items.reduce((t, i) => t + (Number(i.quantity) || 0) * (Number(i.unitPrice) || 0), 0);
+
+  const calculateItemTotal = (item: FormData['items'][number]) =>
+    (Number(item.quantity) || 0) * (Number(item.unitPrice) || 0);
+
+  const calculateRetenueAmount = () => {
+    if (!formData.retenueGarantieEnabled) return 0;
+    return parseFloat((calculateSubtotal() * formData.retenueGarantieRate / 100).toFixed(2));
   };
 
-  const calculateItemTotal = (item: FormData['items'][number]) => {
-    const quantity = Number(item.quantity) || 0;
-    const unitPrice = Number(item.unitPrice) || 0;
-    return quantity * unitPrice; // No VAT for Micro-Entrepreneurs
-  };
-
-  const calculateInvoiceTotal = () => {
-    return formData.items.reduce((total, item) => total + calculateItemTotal(item), 0);
-  };
-
-  const calculateTotalTVA = () => {
-    return 0; // Always 0 for Micro-Entrepreneurs (TVA exempt)
-  };
-
-  const calculateSubtotal = () => {
-    return formData.items.reduce((total, item) => {
-      const quantity = Number(item.quantity) || 0;
-      const unitPrice = Number(item.unitPrice) || 0;
-      return total + (quantity * unitPrice);
-    }, 0);
-  };
+  const calculateInvoiceTotal = () => calculateSubtotal() - calculateRetenueAmount();
 
   const nextStep = () => {
     if (currentStep < 3) setCurrentStep(currentStep + 1);
@@ -357,10 +388,13 @@ export default function CreateInvoicePage() {
         quantity: item.quantity,
         unitPrice: item.unitPrice,
       })),
+      btpInvoiceType: formData.btpInvoiceType !== 'standard' ? formData.btpInvoiceType : null,
+      situationNumber: formData.situationNumber ? parseInt(formData.situationNumber) : null,
+      referenceContract: formData.referenceContract || null,
     });
   }, [formData, userProfile, siretCheck, clients]);
 
-  if (status === 'loading' || loading) {
+  if (status === 'loading') {
     return <div className="d-flex justify-content-center align-items-center vh-100">Chargement...</div>;
   }
 
@@ -457,7 +491,7 @@ export default function CreateInvoicePage() {
                   <div className="fw-semibold mb-1">Extraction IA — Plan Pro</div>
                   <div className="text-muted small mb-3">Passez au Pro pour extraire automatiquement client, lignes et montants depuis vos devis et contrats.</div>
                   <a href="/dashboard/settings#billing" className="btn btn-primary mb-2">
-                    <i className="bi bi-lightning-fill me-2"></i>Passer au Pro — 14 jours offerts
+                    <i className="bi bi-lightning-fill me-2"></i>Passer au Pro — 30 jours offerts
                   </a>
                   <div className="mt-3">
                     <button
@@ -693,6 +727,45 @@ export default function CreateInvoicePage() {
                           </div>
                         );
                       })()}
+
+                      {/* Marchés Publics — Code Service + N° Engagement */}
+                      {isPublicClient && (
+                        <div className="alert alert-info border-info mt-2 mb-0 p-3" style={{ fontSize: '0.85rem' }}>
+                          <div className="fw-semibold mb-2">
+                            <i className="bi bi-building-check me-1"></i>
+                            Entité publique détectée (Chorus Pro)
+                          </div>
+                          <p className="mb-2 text-muted" style={{ fontSize: '0.8rem' }}>
+                            Ce client utilise Chorus Pro. Renseignez les champs obligatoires pour éviter le rejet de votre facture.
+                          </p>
+                          <div className="row g-2">
+                            <div className="col-md-6">
+                              <label className="form-label fw-semibold small mb-1">Code Service <span className="text-danger">*</span></label>
+                              <input
+                                type="text"
+                                className="form-control form-control-sm"
+                                name="codeService"
+                                value={formData.codeService}
+                                onChange={handleInputChange}
+                                placeholder="ex: DGFIP-001"
+                              />
+                              <div className="form-text" style={{ fontSize: '0.75rem' }}>Service destinataire dans l'entité publique</div>
+                            </div>
+                            <div className="col-md-6">
+                              <label className="form-label fw-semibold small mb-1">N° Engagement <span className="text-danger">*</span></label>
+                              <input
+                                type="text"
+                                className="form-control form-control-sm"
+                                name="numeroEngagement"
+                                value={formData.numeroEngagement}
+                                onChange={handleInputChange}
+                                placeholder="ex: 2024-EJ-00042"
+                              />
+                              <div className="form-text" style={{ fontSize: '0.75rem' }}>N° de bon de commande / engagement juridique</div>
+                            </div>
+                          </div>
+                        </div>
+                      )}
                     </div>
 
                     <div className="col-lg-4 col-md-6 col-12">
@@ -760,7 +833,132 @@ export default function CreateInvoicePage() {
                         onChange={handleInputChange}
                       />
                     </div>
+                  </div>
 
+                  {/* BTP sub-contractor section */}
+                  <div className="mt-4 pt-3 border-top">
+                    <h6 className="text-darkGray mb-3 d-flex align-items-center gap-2">
+                      <i className="bi bi-building-gear text-warning"></i>
+                      Options BTP (sous-traitant)
+                      <span className="badge bg-warning text-dark fw-normal" style={{ fontSize: '0.7rem' }}>Optionnel</span>
+                    </h6>
+                    <div className="row g-3">
+                      <div className="col-md-4">
+                        <label className="form-label fw-semibold">Type de facture BTP</label>
+                        <select
+                          className="form-select rounded-input"
+                          name="btpInvoiceType"
+                          value={formData.btpInvoiceType}
+                          onChange={handleInputChange}
+                        >
+                          <option value="standard">Standard</option>
+                          <option value="situation">Facture de situation</option>
+                          <option value="autoliquidation">Autoliquidation TVA</option>
+                        </select>
+                      </div>
+
+                      {formData.btpInvoiceType === 'autoliquidation' && (
+                        <div className="col-12">
+                          <div className="alert alert-info border-0 py-2 mb-0 d-flex align-items-center gap-2" style={{ fontSize: '0.85rem' }}>
+                            <i className="bi bi-info-circle-fill flex-shrink-0"></i>
+                            <span>TVA autoliquidation activée — Art. 283, 2 nonies CGI. La TVA sera à 0 % et le code <strong>AE</strong> sera encodé dans le Factur-X.</span>
+                          </div>
+                        </div>
+                      )}
+
+                      {formData.btpInvoiceType === 'situation' && (
+                        <>
+                          <div className="col-md-3">
+                            <label className="form-label fw-semibold">N° de situation *</label>
+                            <input
+                              type="number"
+                              className="form-control rounded-input"
+                              name="situationNumber"
+                              value={formData.situationNumber}
+                              onChange={handleInputChange}
+                              min="1"
+                              placeholder="ex: 3"
+                            />
+                          </div>
+                          <div className="col-md-5">
+                            <label className="form-label fw-semibold">Référence marché / contrat *</label>
+                            <input
+                              type="text"
+                              className="form-control rounded-input"
+                              name="referenceContract"
+                              value={formData.referenceContract}
+                              onChange={handleInputChange}
+                              placeholder="ex: MARCHE-2025-001"
+                            />
+                          </div>
+                          <div className="col-md-4">
+                            <label className="form-label fw-semibold">Montant HT cumulé précédent (€)</label>
+                            <input
+                              type="number"
+                              className="form-control rounded-input"
+                              name="previousCumulativeAmount"
+                              value={formData.previousCumulativeAmount}
+                              onChange={handleInputChange}
+                              min="0"
+                              step="0.01"
+                              placeholder="0.00"
+                            />
+                          </div>
+                          <div className="col-md-4">
+                            <label className="form-label fw-semibold">N° facture précédente</label>
+                            <input
+                              type="text"
+                              className="form-control rounded-input"
+                              name="previousInvoiceNumber"
+                              value={formData.previousInvoiceNumber}
+                              onChange={handleInputChange}
+                              placeholder="ex: FA-2024-003"
+                            />
+                            <div className="form-text">Référence CII — optionnel</div>
+                          </div>
+                        </>
+                      )}
+
+                      <div className="col-12">
+                        <div className="form-check form-switch">
+                          <input
+                            className="form-check-input"
+                            type="checkbox"
+                            id="retenueGarantieEnabled"
+                            checked={formData.retenueGarantieEnabled}
+                            onChange={(e) => setFormData({ ...formData, retenueGarantieEnabled: e.target.checked })}
+                          />
+                          <label className="form-check-label fw-semibold" htmlFor="retenueGarantieEnabled">
+                            Retenue de garantie
+                          </label>
+                        </div>
+                        {formData.retenueGarantieEnabled && (
+                          <div className="row g-2 mt-1">
+                            <div className="col-auto">
+                              <div className="input-group" style={{ width: '160px' }}>
+                                <input
+                                  type="number"
+                                  className="form-control rounded-input"
+                                  name="retenueGarantieRate"
+                                  value={formData.retenueGarantieRate}
+                                  onChange={(e) => setFormData({ ...formData, retenueGarantieRate: parseFloat(e.target.value) || 5 })}
+                                  min="0"
+                                  max="100"
+                                  step="0.5"
+                                />
+                                <span className="input-group-text">%</span>
+                              </div>
+                            </div>
+                            <div className="col-auto d-flex align-items-center">
+                              <span className="text-muted small">Déduit du net à payer — restitué après levée de réserves</span>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="row g-3 mt-0">
                     <div className="col-12">
                       <label htmlFor="deliveryAddress" className="form-label fw-semibold">
                         <i className="bi bi-geo-alt me-1 text-primary"></i>
@@ -860,34 +1058,22 @@ export default function CreateInvoicePage() {
                           <div className="col-md-3">
                             <label className="form-label fw-semibold">
                               TVA (%)
-                              {isTvaExempt() && (
-                                <small className="text-info d-block">Exemption TVA</small>
-                              )}
+                              <small className="text-info d-block">
+                                {formData.btpInvoiceType === 'autoliquidation' ? 'Autoliquidation' : 'Exemption TVA'}
+                              </small>
                             </label>
-                            {isTvaExempt() ? (
-                              <div className="input-group">
-                                <input 
-                                  type="number" 
-                                  className="form-control rounded-input bg-light" 
-                                  name="tvaRate" 
-                                  value={0} 
-                                  disabled 
-                                />
-                                <span className="input-group-text bg-info text-white">
-                                  <i className="bi bi-info-circle"></i>
-                                </span>
-                              </div>
-                            ) : (
-                              <input 
-                                type="number" 
-                                className="form-control rounded-input" 
-                                name="tvaRate" 
-                                value={isNaN(item.tvaRate) ? '' : item.tvaRate} 
-                                onChange={(e) => handleItemChange(index, e)}
-                                min="0"
-                                max="100"
+                            <div className="input-group">
+                              <input
+                                type="number"
+                                className="form-control rounded-input bg-light"
+                                name="tvaRate"
+                                value={0}
+                                disabled
                               />
-                            )}
+                              <span className="input-group-text bg-info text-white">
+                                <i className="bi bi-info-circle"></i>
+                              </span>
+                            </div>
                           </div>
 
                           <div className="col-md-3">
@@ -949,13 +1135,15 @@ export default function CreateInvoicePage() {
                           <span className="text-mediumGray">Sous-total HT</span>
                           <span className="fw-semibold">{formatCurrency(calculateSubtotal())}</span>
                         </div>
-                        <div className="d-flex justify-content-between mb-2">
-                          <span className="text-mediumGray">TVA</span>
-                          <span className="fw-semibold">{formatCurrency(calculateTotalTVA())}</span>
-                        </div>
+                        {formData.retenueGarantieEnabled && (
+                          <div className="d-flex justify-content-between mb-2 text-warning">
+                            <span>Retenue de garantie ({formData.retenueGarantieRate}%)</span>
+                            <span className="fw-semibold">− {formatCurrency(calculateRetenueAmount())}</span>
+                          </div>
+                        )}
                         <hr />
                         <div className="d-flex justify-content-between">
-                          <span className="fw-bold text-darkGray">Total</span>
+                          <span className="fw-bold text-darkGray">Net à payer</span>
                           <span className="fw-bold text-primary fs-5">{formatCurrency(calculateInvoiceTotal())}</span>
                         </div>
                       </div>
@@ -1008,13 +1196,15 @@ export default function CreateInvoicePage() {
                     <span className="text-mediumGray">Sous-total HT</span>
                     <span className="fw-semibold">{formatCurrency(calculateSubtotal())}</span>
                   </div>
-                  <div className="d-flex justify-content-between mb-3">
-                    <span className="text-mediumGray">TVA</span>
-                    <span className="fw-semibold">{formatCurrency(calculateTotalTVA())}</span>
-                  </div>
+                  {formData.retenueGarantieEnabled && (
+                    <div className="d-flex justify-content-between mb-2" style={{ color: '#b45309' }}>
+                      <span style={{ fontSize: '0.85rem' }}>Retenue ({formData.retenueGarantieRate}%)</span>
+                      <span className="fw-semibold">− {formatCurrency(calculateRetenueAmount())}</span>
+                    </div>
+                  )}
                   <hr />
                   <div className="d-flex justify-content-between">
-                    <span className="fw-bold text-darkGray">Total</span>
+                    <span className="fw-bold text-darkGray">Net à payer</span>
                     <span className="fw-bold text-primary">{formatCurrency(calculateInvoiceTotal())}</span>
                   </div>
                 </div>

--- a/src/app/dashboard/invoices/[invoiceId]/page.tsx
+++ b/src/app/dashboard/invoices/[invoiceId]/page.tsx
@@ -58,6 +58,19 @@ type InvoiceDetail = {
   issuerLegalStatus?: string | null;
   issuerShareCapital?: string | null;
   issuerApeCode?: string | null;
+  btpInvoiceType?: string | null;
+  retenueGarantieRate?: number | string | null;
+  retenueGarantieAmount?: number | string | null;
+  situationNumber?: number | null;
+  referenceContract?: string | null;
+  previousCumulativeAmount?: number | string | null;
+  previousInvoiceNumber?: string | null;
+  codeService?: string | null;
+  numeroEngagement?: string | null;
+  reminderEnabled?: boolean;
+  reminderCount?: number;
+  nextReminderAt?: string | null;
+  lastReminderSentAt?: string | null;
 };
 
 const formatCurrency = (value: unknown) => {
@@ -205,6 +218,7 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
   const [preflightLoading, setPreflightLoading] = useState(false);
   const [sendingReminder, setSendingReminder] = useState(false);
   const [reminderSent, setReminderSent] = useState(false);
+  const [togglingReminder, setTogglingReminder] = useState(false);
   const [stripeConnected, setStripeConnected] = useState(false);
   const [isPro, setIsPro] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -696,6 +710,114 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
           </div>
           )}
 
+          {/* BTP card — shown when invoice has a BTP type */}
+          {invoice.btpInvoiceType && invoice.btpInvoiceType !== 'standard' && (
+            <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
+              <h2 className="h5 mb-3">
+                <i className="bi bi-building-gear me-2 text-primary"></i>BTP
+              </h2>
+              <div className="vstack gap-2 small">
+                <div className="d-flex justify-content-between">
+                  <span className="text-muted">Type</span>
+                  <span className="fw-semibold">
+                    {invoice.btpInvoiceType === 'autoliquidation'
+                      ? 'Autoliquidation TVA'
+                      : 'Facture de situation'}
+                  </span>
+                </div>
+                {invoice.btpInvoiceType === 'autoliquidation' && (
+                  <div className="alert alert-warning py-2 mb-0" style={{ fontSize: '0.75rem' }}>
+                    TVA autoliquidée — art. 283, 2 nonies CGI
+                  </div>
+                )}
+                {invoice.btpInvoiceType === 'situation' && (
+                  <>
+                    {invoice.situationNumber != null && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">N° de situation</span>
+                        <span>{invoice.situationNumber}</span>
+                      </div>
+                    )}
+                    {invoice.referenceContract && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Réf. contrat</span>
+                        <span className="text-truncate ms-3" style={{ maxWidth: 160 }}>{invoice.referenceContract}</span>
+                      </div>
+                    )}
+                    {invoice.previousInvoiceNumber && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Facture précédente</span>
+                        <span>{invoice.previousInvoiceNumber}</span>
+                      </div>
+                    )}
+                    {invoice.previousCumulativeAmount != null && Number(invoice.previousCumulativeAmount) > 0 && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Cumul précédent</span>
+                        <span>{formatCurrency(invoice.previousCumulativeAmount)}</span>
+                      </div>
+                    )}
+                  </>
+                )}
+                {invoice.retenueGarantieAmount != null && Number(invoice.retenueGarantieAmount) > 0 && (
+                  <>
+                    <hr className="my-1" />
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Retenue de garantie</span>
+                      <span className="text-warning fw-semibold">
+                        {invoice.retenueGarantieRate
+                          ? `${Number(invoice.retenueGarantieRate) * 100} %`
+                          : ''} — {formatCurrency(invoice.retenueGarantieAmount)}
+                      </span>
+                    </div>
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Net à payer</span>
+                      <span className="fw-semibold text-primary">
+                        {formatCurrency(Number(invoice.totalAmount) - Number(invoice.retenueGarantieAmount))}
+                      </span>
+                    </div>
+                  </>
+                )}
+                {/* B2G Chorus Pro routing — shown when codeService or numeroEngagement is set */}
+                {(invoice.codeService || invoice.numeroEngagement) && (
+                  <>
+                    <hr className="my-1" />
+                    <div className="text-muted fw-semibold" style={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                      Routage Chorus Pro
+                    </div>
+                    {invoice.codeService && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Code Service</span>
+                        <span className="font-monospace">{invoice.codeService}</span>
+                      </div>
+                    )}
+                    {!invoice.codeService && invoice.transactionType === 'B2G' && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Code Service</span>
+                        <span className="text-danger small"><i className="bi bi-exclamation-triangle me-1"></i>Manquant</span>
+                      </div>
+                    )}
+                    {invoice.numeroEngagement && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">N° Engagement</span>
+                        <span className="font-monospace">{invoice.numeroEngagement}</span>
+                      </div>
+                    )}
+                  </>
+                )}
+                {/* Show B2G routing section even when both fields are empty, for B2G invoices */}
+                {!invoice.codeService && !invoice.numeroEngagement && invoice.transactionType === 'B2G' && (
+                  <>
+                    <hr className="my-1" />
+                    <div className="alert alert-warning py-2 mb-0 small">
+                      <i className="bi bi-exclamation-triangle me-1"></i>
+                      Code Service manquant — requis pour le dépôt Chorus Pro.
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
           <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
             <h2 className="h5 mb-3">Sortie Factur-X</h2>
             <div className="d-flex justify-content-between align-items-center mb-3">
@@ -890,6 +1012,73 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
             )}
           </div>
 
+          {/* Auto-reminder status card — only shown on issued, unpaid invoices */}
+          {invoice.workflowStatus === 'issued' && invoice.paymentStatus !== 'paid' && (
+            <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
+              <div className="d-flex justify-content-between align-items-center mb-3">
+                <h2 className="h5 mb-0">
+                  <i className="bi bi-bell me-2 text-primary"></i>Relances automatiques
+                </h2>
+                <div className="form-check form-switch mb-0">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    role="switch"
+                    id="invoiceReminderToggle"
+                    checked={invoice.reminderEnabled ?? true}
+                    disabled={togglingReminder}
+                    onChange={async (e) => {
+                      setTogglingReminder(true);
+                      try {
+                        const res = await fetch(`/api/invoices/${invoiceId}/reminders`, {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ enabled: e.target.checked }),
+                        });
+                        if (res.ok) {
+                          const data = await res.json();
+                          setInvoice((prev) => prev ? { ...prev, reminderEnabled: data.reminderEnabled, nextReminderAt: data.nextReminderAt } : prev);
+                        }
+                      } finally {
+                        setTogglingReminder(false);
+                      }
+                    }}
+                  />
+                  <label className="form-check-label visually-hidden" htmlFor="invoiceReminderToggle">Activer</label>
+                </div>
+              </div>
+
+              {invoice.reminderEnabled ? (
+                <div className="vstack gap-2 small">
+                  {invoice.nextReminderAt ? (
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Prochain rappel</span>
+                      <span className="fw-semibold">
+                        {new Date(invoice.nextReminderAt).toLocaleDateString('fr-FR')}
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="text-muted">Calendrier de relance épuisé.</div>
+                  )}
+                  {invoice.reminderCount !== undefined && invoice.reminderCount > 0 && (
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Rappels envoyés</span>
+                      <span>{invoice.reminderCount}</span>
+                    </div>
+                  )}
+                  {invoice.lastReminderSentAt && (
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Dernier envoi</span>
+                      <span>{new Date(invoice.lastReminderSentAt).toLocaleDateString('fr-FR')}</span>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="text-muted small">Les relances automatiques sont désactivées pour cette facture.</div>
+              )}
+            </div>
+          )}
+
           <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
             <h2 className="h5 mb-3">Client</h2>
             <div className="mb-2 fw-semibold">{invoice.client?.name || invoice.clientName || 'Client non renseigné'}</div>
@@ -918,7 +1107,11 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
                       style={{
                         width: 10, height: 10,
                         borderRadius: '50%',
-                        background: log.action === 'issued' ? '#198754' : log.action === 'blocked' ? '#dc3545' : '#6c757d',
+                        background: log.action === 'issued' ? '#198754'
+                        : log.action === 'blocked' ? '#dc3545'
+                        : log.action === 'mise_en_demeure_sent' ? '#7f1d1d'
+                        : log.action === 'reminder_sent' ? '#0d6efd'
+                        : '#6c757d',
                         position: 'absolute', left: '-1.4rem', top: 4,
                       }}
                     />
@@ -926,11 +1119,17 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
                       {log.action === 'issued' && '✓ Facture émise'}
                       {log.action === 'blocked' && '⚠ Facture bloquée'}
                       {log.action === 'exception_resolved' && '↩ Exception résolue'}
-                      {log.action === 'reminder_sent' && '📧 Rappel envoyé'}
+                      {log.action === 'reminder_sent' && (
+                        log.metadata?.auto
+                          ? '📧 Rappel automatique envoyé'
+                          : '📧 Rappel envoyé (manuel)'
+                      )}
+                      {log.action === 'mise_en_demeure_sent' && '⚖ Mise en demeure envoyée'}
                       {log.action === 'facturx_generated' && '✓ Factur-X généré'}
                       {log.action === 'facturx_failed' && '✗ Génération Factur-X échouée'}
                       {log.action === 'workflow_updated' && '→ Workflow mis à jour'}
                       {log.action === 'readiness_changed' && '→ Readiness modifiée'}
+                      {!['issued','blocked','exception_resolved','reminder_sent','mise_en_demeure_sent','facturx_generated','facturx_failed','workflow_updated','readiness_changed'].includes(log.action) && `→ ${log.action}`}
                     </div>
                     <div className="text-muted" style={{ fontSize: '0.75rem' }}>
                       {log.user?.name || log.user?.email || 'Système'} — {new Date(log.createdAt).toLocaleDateString('fr-FR')} {new Date(log.createdAt).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}

--- a/src/domains/invoices/facturx/invoice-to-cii.ts
+++ b/src/domains/invoices/facturx/invoice-to-cii.ts
@@ -27,22 +27,30 @@ export interface FacturxInvoiceInput {
   legalMentions?: string | null;
   // EN 16931 EXTENDED fields
   transactionType?: 'B2B' | 'B2C' | 'B2G' | null;
-  buyerReference?: string | null;        // numéro de bon de commande acheteur
+  buyerReference?: string | null;        // N° engagement / bon de commande (BT-13)
+  codeService?: string | null;           // Code service destinataire Chorus Pro (BT-10)
+  cadreDeTravail?: string | null;        // Cadre de facturation Chorus Pro (A1/A2…) — SpecifiedProcuringProject/ID
   deliveryAddress?: string | null;       // adresse de livraison / prestation
   paymentTerms?: string | null;          // conditions de paiement texte libre
   latePenaltyRate?: string | null;       // taux de pénalités de retard
   recoveryIndemnity?: number | null;     // indemnité forfaitaire de recouvrement (€40)
+  // BTP sub-contractor fields
+  btpInvoiceType?: 'standard' | 'situation' | 'autoliquidation' | null;
+  retenueGarantieAmount?: number | null; // retenue de garantie deduction in EUR
+  situationNumber?: number | null;       // numéro de situation (e.g. 3)
+  referenceContract?: string | null;     // référence du marché / contrat
+  previousCumulativeAmount?: number | null; // montant HT cumulé précédent
+  previousInvoiceNumber?: string | null; // n° facture précédente (situation)
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+const XML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;',
+};
+
 function escapeXml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;");
+  return value.replace(/[&<>"']/g, (ch) => XML_ESCAPE_MAP[ch]);
 }
 
 /** Any ISO date string → YYYYMMDD (CII format 102). Handles both "YYYY-MM-DD" and full ISO timestamps. */
@@ -83,12 +91,13 @@ interface TaxGroup {
   calculatedAmount: number;
 }
 
-function aggregateTaxes(lines: FacturxLineItem[]): TaxGroup[] {
+function aggregateTaxes(lines: FacturxLineItem[], isAutoliquidation: boolean): TaxGroup[] {
   const groups = new Map<string, TaxGroup>();
   for (const line of lines) {
     const lineTotal = line.quantity * line.unitPrice;
     const taxAmt = parseFloat((lineTotal * line.taxRate / 100).toFixed(2));
     const key = `${line.taxRate}`;
+    const categoryCode = isAutoliquidation ? "AE" : (line.taxRate === 0 ? "E" : "S");
     const existing = groups.get(key);
     if (existing) {
       existing.basisAmount = parseFloat((existing.basisAmount + lineTotal).toFixed(2));
@@ -96,7 +105,7 @@ function aggregateTaxes(lines: FacturxLineItem[]): TaxGroup[] {
     } else {
       groups.set(key, {
         typeCode: "VAT",
-        categoryCode: line.taxRate === 0 ? "E" : "S",
+        categoryCode,
         rate: line.taxRate,
         basisAmount: parseFloat(lineTotal.toFixed(2)),
         calculatedAmount: taxAmt,
@@ -133,14 +142,25 @@ function renderParty(party: FacturxParty, tag: string): string {
 // ── Main builder ──────────────────────────────────────────────────────────────
 
 export function buildFacturxXml(input: FacturxInvoiceInput): string {
-  const taxes = aggregateTaxes(input.lines);
+  const isAutoliquidation = input.btpInvoiceType === 'autoliquidation';
+  const isSituation = input.btpInvoiceType === 'situation';
+  const retenueAmount = (input.retenueGarantieAmount != null && input.retenueGarantieAmount > 0)
+    ? input.retenueGarantieAmount
+    : 0;
+
+  const taxes = aggregateTaxes(input.lines, isAutoliquidation);
   const lineTotal = input.lines.reduce((s, l) => s + l.quantity * l.unitPrice, 0);
   const taxTotal = taxes.reduce((s, t) => s + t.calculatedAmount, 0);
-  const grandTotal = parseFloat((lineTotal + taxTotal).toFixed(2));
+  const taxBasis = parseFloat((lineTotal - retenueAmount).toFixed(2));
+  const grandTotal = parseFloat((taxBasis + taxTotal).toFixed(2));
+
   const lineTotalStr = lineTotal.toFixed(2);
   const taxTotalStr = taxTotal.toFixed(2);
+  const taxBasisStr = taxBasis.toFixed(2);
   const grandTotalStr = grandTotal.toFixed(2);
-  const dueStr = input.totalAmount.toFixed(2);
+
+  // Dominant tax category for the retenue allowance charge
+  const dominantTaxCat = taxes.length > 0 ? taxes[0] : { categoryCode: isAutoliquidation ? 'AE' : 'E', rate: 0 };
 
   const linesXml = input.lines
     .map(
@@ -163,7 +183,7 @@ export function buildFacturxXml(input: FacturxInvoiceInput): string {
       <ram:SpecifiedLineTradeSettlement>
         <ram:ApplicableTradeTax>
           <ram:TypeCode>VAT</ram:TypeCode>
-          <ram:CategoryCode>${line.taxRate === 0 ? "E" : "S"}</ram:CategoryCode>
+          <ram:CategoryCode>${isAutoliquidation ? "AE" : (line.taxRate === 0 ? "E" : "S")}</ram:CategoryCode>
           <ram:RateApplicablePercent>${line.taxRate.toFixed(2)}</ram:RateApplicablePercent>
         </ram:ApplicableTradeTax>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
@@ -180,19 +200,57 @@ export function buildFacturxXml(input: FacturxInvoiceInput): string {
     <ram:ApplicableTradeTax>
       <ram:CalculatedAmount>${t.calculatedAmount.toFixed(2)}</ram:CalculatedAmount>
       <ram:TypeCode>${t.typeCode}</ram:TypeCode>
+      ${isAutoliquidation ? `<ram:ExemptionReason>Autoliquidation de TVA - Art. 283, 2 nonies CGI</ram:ExemptionReason>` : ""}
       <ram:BasisAmount>${t.basisAmount.toFixed(2)}</ram:BasisAmount>
       <ram:CategoryCode>${t.categoryCode}</ram:CategoryCode>
+      ${isAutoliquidation ? `<ram:ExemptionReasonCode>VATEX-EU-AE</ram:ExemptionReasonCode>` : ""}
       <ram:RateApplicablePercent>${t.rate.toFixed(2)}</ram:RateApplicablePercent>
     </ram:ApplicableTradeTax>`
     )
     .join("");
+
+  // Retenue de garantie — document-level allowance (ChargeIndicator=false)
+  const retenueXml = retenueAmount > 0
+    ? `
+    <ram:SpecifiedTradeAllowanceCharge>
+      <ram:ChargeIndicator>
+        <udt:Indicator>false</udt:Indicator>
+      </ram:ChargeIndicator>
+      <ram:ActualAmount>${retenueAmount.toFixed(2)}</ram:ActualAmount>
+      <ram:Reason>Retenue de garantie</ram:Reason>
+      <ram:CategoryTradeTax>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:CategoryCode>${dominantTaxCat.categoryCode}</ram:CategoryCode>
+        <ram:RateApplicablePercent>${dominantTaxCat.rate.toFixed(2)}</ram:RateApplicablePercent>
+      </ram:CategoryTradeTax>
+    </ram:SpecifiedTradeAllowanceCharge>`
+    : "";
+
+  // Preceding invoice reference for situation invoices (BT-25)
+  const precedingInvoiceXml = isSituation && input.previousInvoiceNumber
+    ? `
+      <ram:InvoiceReferencedDocument>
+        <ram:IssuerAssignedID>${escapeXml(input.previousInvoiceNumber)}</ram:IssuerAssignedID>
+      </ram:InvoiceReferencedDocument>`
+    : "";
 
   // Business process context — maps transactionType to BII profile URNs
   const bpUrn = input.transactionType === 'B2G'
     ? 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0'
     : 'urn:factur-x.eu:1p0:en16931';
 
-  // Delivery block — emit ShipToTradeParty only when deliveryAddress is provided
+  // Situation note — appended as IncludedNote in ExchangedDocument
+  const situationNoteContent = isSituation && input.situationNumber != null
+    ? [
+        `Situation n°${input.situationNumber}`,
+        input.referenceContract ? `Contrat : ${input.referenceContract}` : null,
+        input.previousCumulativeAmount != null
+          ? `Montant HT cumulé précédent : ${input.previousCumulativeAmount.toFixed(2)} €`
+          : null,
+      ].filter(Boolean).join(' — ')
+    : null;
+
+  // Delivery block
   const deliveryXml = input.deliveryAddress
     ? `
     <ram:ApplicableHeaderTradeDelivery>
@@ -206,7 +264,7 @@ export function buildFacturxXml(input: FacturxInvoiceInput): string {
     </ram:ApplicableHeaderTradeDelivery>`
     : `<ram:ApplicableHeaderTradeDelivery/>`;
 
-  // Payment terms — description + due date + late penalty note
+  // Payment terms
   const penaltyNote = [
     input.paymentTerms,
     input.latePenaltyRate ? `Pénalités de retard : ${input.latePenaltyRate}` : null,
@@ -220,6 +278,11 @@ export function buildFacturxXml(input: FacturxInvoiceInput): string {
           <udt:DateTimeString format="102">${ciiDate(input.dueDate)}</udt:DateTimeString>
         </ram:DueDateDateTime>
       </ram:SpecifiedTradePaymentTerms>`;
+
+  // Monetary summary — AllowanceTotalAmount only present when retenue > 0
+  const allowanceXml = retenueAmount > 0
+    ? `<ram:AllowanceTotalAmount>${retenueAmount.toFixed(2)}</ram:AllowanceTotalAmount>`
+    : "";
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <rsm:CrossIndustryInvoice
@@ -241,44 +304,33 @@ export function buildFacturxXml(input: FacturxInvoiceInput): string {
       <udt:DateTimeString format="102">${ciiDate(input.invoiceDate)}</udt:DateTimeString>
     </ram:IssueDateTime>
     ${input.legalMentions ? `<ram:IncludedNote><ram:Content>${escapeXml(input.legalMentions)}</ram:Content></ram:IncludedNote>` : ""}
+    ${situationNoteContent ? `<ram:IncludedNote><ram:Content>${escapeXml(situationNoteContent)}</ram:Content></ram:IncludedNote>` : ""}
   </rsm:ExchangedDocument>
   <rsm:SupplyChainTradeTransaction>
     ${linesXml}
     <ram:ApplicableHeaderTradeAgreement>
+      ${input.codeService ? `<ram:BuyerReference>${escapeXml(input.codeService)}</ram:BuyerReference>` : ''}
       ${input.buyerReference ? `<ram:BuyerOrderReferencedDocument><ram:IssuerAssignedID>${escapeXml(input.buyerReference)}</ram:IssuerAssignedID></ram:BuyerOrderReferencedDocument>` : ''}
       ${renderParty(input.seller, "SellerTradeParty")}
       ${renderParty(input.buyer, "BuyerTradeParty")}
+      ${input.cadreDeTravail ? `<ram:SpecifiedProcuringProject><ram:ID>${escapeXml(input.cadreDeTravail)}</ram:ID></ram:SpecifiedProcuringProject>` : ''}
     </ram:ApplicableHeaderTradeAgreement>
     ${deliveryXml}
     <ram:ApplicableHeaderTradeSettlement>
       <ram:InvoiceCurrencyCode>${escapeXml(input.currency)}</ram:InvoiceCurrencyCode>
       ${taxesXml}
       ${paymentTermsXml}
+      ${retenueXml}
+      ${precedingInvoiceXml}
       <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
         <ram:LineTotalAmount>${lineTotalStr}</ram:LineTotalAmount>
-        <ram:TaxBasisTotalAmount>${lineTotalStr}</ram:TaxBasisTotalAmount>
+        ${allowanceXml}
+        <ram:TaxBasisTotalAmount>${taxBasisStr}</ram:TaxBasisTotalAmount>
         <ram:TaxTotalAmount>${taxTotalStr}</ram:TaxTotalAmount>
         <ram:GrandTotalAmount>${grandTotalStr}</ram:GrandTotalAmount>
-        <ram:DuePayableAmount>${dueStr}</ram:DuePayableAmount>
+        <ram:DuePayableAmount>${grandTotalStr}</ram:DuePayableAmount>
       </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
     </ram:ApplicableHeaderTradeSettlement>
   </rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>`;
-}
-
-/** Kept for compatibility — wraps buildFacturxXml input into a plain object */
-export function mapInvoiceToCiiModel(input: FacturxInvoiceInput) {
-  return {
-    document: {
-      invoiceNumber: input.invoiceNumber,
-      invoiceDate: input.invoiceDate,
-      dueDate: input.dueDate,
-      currency: input.currency,
-      totalAmount: input.totalAmount,
-      legalMentions: input.legalMentions ?? "",
-    },
-    seller: input.seller,
-    buyer: input.buyer,
-    lines: input.lines,
-  };
 }

--- a/src/domains/invoices/invoice-readiness.ts
+++ b/src/domains/invoices/invoice-readiness.ts
@@ -12,7 +12,9 @@ export type InvoiceReadinessReasonCode =
   | "missing_issuer_siret"
   | "missing_payment_terms"
   | "missing_late_penalty_rate"
-  | "missing_legal_mentions";
+  | "missing_legal_mentions"
+  | "situation_missing_number"
+  | "situation_missing_contract";
 
 export interface InvoiceReadinessReason {
   code: InvoiceReadinessReasonCode;
@@ -39,6 +41,10 @@ export interface InvoiceReadinessInput {
     quantity?: number | null;
     unitPrice?: number | null;
   }> | null;
+  // BTP sub-contractor fields
+  btpInvoiceType?: 'standard' | 'situation' | 'autoliquidation' | null;
+  situationNumber?: number | null;
+  referenceContract?: string | null;
 }
 
 export interface InvoiceReadinessResult {
@@ -112,6 +118,16 @@ export function evaluateInvoiceReadiness(input: InvoiceReadinessInput): InvoiceR
   // Legal mentions
   if (!input.legalMentions) {
     blockingReasons.push(blocking("missing_legal_mentions", "Les mentions légales sont requises."));
+  }
+
+  // BTP: facture de situation requires situation number + contract reference
+  if (input.btpInvoiceType === 'situation') {
+    if (!input.situationNumber) {
+      blockingReasons.push(blocking("situation_missing_number", "Le numéro de situation est requis pour une facture de situation BTP."));
+    }
+    if (!input.referenceContract) {
+      blockingReasons.push(blocking("situation_missing_contract", "La référence du marché / contrat est requise pour une facture de situation BTP."));
+    }
   }
 
   return {

--- a/src/lib/facturx-pdf-generator.tsx
+++ b/src/lib/facturx-pdf-generator.tsx
@@ -57,6 +57,12 @@ export async function generateFacturxInMemory(invoice: any): Promise<Buffer> {
       paymentTerms: invoice.paymentTerms,
       latePenaltyRate: invoice.latePenaltyRate,
       recoveryIndemnity: invoice.recoveryIndemnity != null ? safeToNumber(invoice.recoveryIndemnity) : null,
+      btpInvoiceType: invoice.btpInvoiceType as 'standard' | 'situation' | 'autoliquidation' | null ?? null,
+      retenueGarantieAmount: invoice.retenueGarantieAmount != null ? safeToNumber(invoice.retenueGarantieAmount) : null,
+      situationNumber: invoice.situationNumber ?? null,
+      referenceContract: invoice.referenceContract ?? null,
+      previousCumulativeAmount: invoice.previousCumulativeAmount != null ? safeToNumber(invoice.previousCumulativeAmount) : null,
+      previousInvoiceNumber: invoice.previousInvoiceNumber ?? null,
     },
     pdfBuffer
   );

--- a/src/lib/sirene-api.ts
+++ b/src/lib/sirene-api.ts
@@ -18,6 +18,10 @@ export interface SireneEtablissement {
     libelleCommuneEtablissement: string | null;
   };
   etatAdministratifEtablissement: 'A' | 'F'; // A=active, F=closed
+  uniteLegale?: {
+    categorieJuridiqueUniteLegale?: string | null;
+    denominationUniteLegale?: string | null;
+  };
 }
 
 export interface SireneResult {
@@ -26,8 +30,24 @@ export interface SireneResult {
   companyName: string | null;
   address: string | null;
   active: boolean;
+  isPublicEntity: boolean;  // true when categorieJuridique indicates a Chorus Pro public buyer
+  categorieJuridique: string | null;
   raw: SireneEtablissement | null;
   error?: string;
+}
+
+/**
+ * Returns true when the INSEE categorieJuridique code indicates a public entity
+ * that uses Chorus Pro (État, collectivités, EPIC/EPA, organismes publics).
+ * Codes 1xxx–3xxx are state/public-law bodies; 7xxx are public services.
+ */
+export function isPublicEntityByCode(code: string | null | undefined): boolean {
+  if (!code) return false;
+  const n = parseInt(code, 10);
+  if (isNaN(n)) return false;
+  // 1000–3999: État, organismes de l'État, personnes soumises au droit administratif
+  // 7000–7999: Administrations et services publics
+  return (n >= 1000 && n < 4000) || (n >= 7000 && n < 8000);
 }
 
 // E2-S2: Luhn-based SIRET format validator (14 digits, valid Luhn)
@@ -69,7 +89,7 @@ function buildAddress(e: SireneEtablissement): string | null {
 async function fetchFromSirene(siret: string): Promise<SireneResult> {
   const apiKey = process.env.SIRENE_API_KEY;
   if (!apiKey) {
-    return { valid: false, siret, companyName: null, address: null, active: false, raw: null, error: 'SIRENE_API_KEY not configured' };
+    return { valid: false, siret, companyName: null, address: null, active: false, isPublicEntity: false, categorieJuridique: null, raw: null, error: 'SIRENE_API_KEY not configured' };
   }
 
   const res = await fetch(`${SIRENE_BASE}/siret/${siret}`, {
@@ -78,15 +98,16 @@ async function fetchFromSirene(siret: string): Promise<SireneResult> {
   });
 
   if (res.status === 404) {
-    return { valid: false, siret, companyName: null, address: null, active: false, raw: null, error: 'SIRET introuvable dans le répertoire SIRENE' };
+    return { valid: false, siret, companyName: null, address: null, active: false, isPublicEntity: false, categorieJuridique: null, raw: null, error: 'SIRET introuvable dans le répertoire SIRENE' };
   }
 
   if (!res.ok) {
-    return { valid: false, siret, companyName: null, address: null, active: false, raw: null, error: `Erreur SIRENE: ${res.status}` };
+    return { valid: false, siret, companyName: null, address: null, active: false, isPublicEntity: false, categorieJuridique: null, raw: null, error: `Erreur SIRENE: ${res.status}` };
   }
 
   const json = await res.json();
   const etablissement: SireneEtablissement = json.etablissement;
+  const categorieJuridique = etablissement.uniteLegale?.categorieJuridiqueUniteLegale ?? null;
 
   return {
     valid: true,
@@ -94,6 +115,8 @@ async function fetchFromSirene(siret: string): Promise<SireneResult> {
     companyName: buildCompanyName(etablissement),
     address: buildAddress(etablissement),
     active: etablissement.etatAdministratifEtablissement === 'A',
+    isPublicEntity: isPublicEntityByCode(categorieJuridique),
+    categorieJuridique,
     raw: etablissement,
   };
 }
@@ -102,7 +125,7 @@ export async function lookupSiret(siret: string): Promise<SireneResult> {
   const cleaned = siret.replace(/\s/g, '');
 
   if (!validateSiretFormat(cleaned)) {
-    return { valid: false, siret: cleaned, companyName: null, address: null, active: false, raw: null, error: 'Format SIRET invalide (14 chiffres requis)' };
+    return { valid: false, siret: cleaned, companyName: null, address: null, active: false, isPublicEntity: false, categorieJuridique: null, raw: null, error: 'Format SIRET invalide (14 chiffres requis)' };
   }
 
   // Check cache


### PR DESCRIPTION
## Summary

- **Schema**: `BtpInvoiceType` enum + 11 new Invoice fields (BTP fields, Chorus Pro routing: `codeService`, `numeroEngagement`, `previousInvoiceNumber`)
- **Factur-X XML**: AE tax category for autoliquidation (art. 283, 2 nonies CGI), `IncludedNote` for situation invoices, `SpecifiedTradeAllowanceCharge` for retenue de garantie, `BuyerReference` (BT-10) / `BuyerOrderReferencedDocument` (BT-13) / `SpecifiedProcuringProject` (cadre A1/A2)
- **InvoicePdf**: full rewrite — autoliquidation banner, situation header with cumulative amounts, retenue deduction + net à payer, BTP legal mentions auto-injected
- **SIRENE API**: public entity detection via `categorieJuridique` prefix (1xxx–3xxx = État/public, 7xxx = administrations)
- **Create-invoice UI**: BTP section (type selector, situation fields, retenue toggle), Marchés Publics banner + Code Service / N° Engagement fields shown when SIRET lookup confirms public entity
- **PPF preflight**: B2G blocker when `codeService` missing, warning when `numeroEngagement` absent
- **Invoice detail**: BTP card showing type, autoliquidation badge, situation details, retenue/net à payer, B2G routing section with `Manquant` warning

## Test plan

- [ ] Create invoice with `btpInvoiceType = autoliquidation` — verify AE tag in XML, yellow banner in PDF, 0% TVA row
- [ ] Create facture de situation — verify `IncludedNote`, cumulative amounts in PDF header
- [ ] Create invoice with retenue — verify `SpecifiedTradeAllowanceCharge` in XML, deduction + net à payer in PDF
- [ ] Look up public entity SIRET — verify Marchés Publics banner appears, Code Service / N° Engagement fields save correctly
- [ ] Submit B2G invoice to PPF preflight without `codeService` — verify blocker appears
- [ ] Check invoice detail BTP card renders correctly for all three BTP types