### PR TITLE
Feat: automatic payment reminders — reminder engine, settings, per-invoice toggle, dashboard widget

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,9 @@ model User {
   pisteClientId       String?
   pisteClientSecret   String?
   pisteEnv            String   @default("sandbox")
+  // Automatic payment reminder preferences
+  reminderEnabled           Boolean   @default(true)
+  reminderSchedule          Json?     // [{ triggerDays: number, label: string }] — null = use default ladder
   accounts            Account[]
   sessions            Session[]
   clients               Client[]
@@ -170,6 +173,11 @@ model Invoice {
   ppfSubmittedAt      DateTime?
   ppfLastEventAt      DateTime?
   ppfError            String?
+  // Automatic payment reminder tracking
+  reminderEnabled     Boolean   @default(true)
+  reminderCount       Int       @default(0)
+  lastReminderSentAt  DateTime?
+  nextReminderAt      DateTime?
 }
 
 model InvoiceItem {

--- a/src/app/api/cron/payment-reminders/route.ts
+++ b/src/app/api/cron/payment-reminders/route.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { sendReminderEmail } from '@/lib/email-service';
-import { logActivity } from '@/domains/invoices/activity-log';
 import {
   computeNextReminderDate,
   isLastReminder,
   parseReminderSchedule,
-  DEFAULT_REMINDER_SCHEDULE,
 } from '@/domains/invoices/reminder-schedule';
 
 // GET /api/cron/payment-reminders

--- a/src/app/api/cron/payment-reminders/route.ts
+++ b/src/app/api/cron/payment-reminders/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { sendReminderEmail } from '@/lib/email-service';
+import { logActivity } from '@/domains/invoices/activity-log';
+import {
+  computeNextReminderDate,
+  isLastReminder,
+  parseReminderSchedule,
+  DEFAULT_REMINDER_SCHEDULE,
+} from '@/domains/invoices/reminder-schedule';
+
+// GET /api/cron/payment-reminders
+// Fires automatic payment reminders on the configured ladder.
+// Called daily at 09:00 by Vercel cron (see vercel.json).
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('Authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const now = new Date();
+
+  // Fetch eligible invoices — strict nextReminderAt <= now prevents double-firing
+  const invoices = await prisma.invoice.findMany({
+    where: {
+      workflowStatus: 'issued',
+      paymentStatus: { not: 'paid' },
+      reminderEnabled: true,
+      nextReminderAt: { lte: now },
+      user: { reminderEnabled: true },
+    },
+    include: {
+      client: { select: { email: true, name: true } },
+      user: { select: { reminderSchedule: true } },
+    },
+    take: 50, // stay within cron timeout
+    orderBy: { nextReminderAt: 'asc' },
+  });
+
+  let sent = 0;
+  let skipped = 0;
+  const errors: string[] = [];
+
+  for (const invoice of invoices) {
+    const clientEmail = invoice.clientEmail ?? invoice.client?.email;
+
+    if (!clientEmail) {
+      // No email — exhaust the ladder so we don't re-check daily forever
+      await prisma.invoice.update({
+        where: { id: invoice.id },
+        data: { nextReminderAt: null },
+      });
+      skipped++;
+      continue;
+    }
+
+    const schedule = parseReminderSchedule(invoice.user?.reminderSchedule);
+    const isFinal = isLastReminder(invoice.reminderCount, schedule);
+    const daysOverdue = Math.floor(
+      (now.getTime() - new Date(invoice.dueDate).getTime()) / 86_400_000
+    );
+
+    try {
+      await sendReminderEmail({
+        to: clientEmail,
+        clientName: invoice.clientName ?? invoice.client?.name ?? 'Client',
+        issuerName: invoice.issuerName,
+        invoiceNumber: invoice.invoiceNumber,
+        totalAmount: Number(invoice.totalAmount),
+        dueDate: invoice.dueDate,
+        daysOverdue: daysOverdue > 0 ? daysOverdue : undefined,
+        reminderCount: invoice.reminderCount,
+        isMiseEnDemeure: isFinal,
+      });
+
+      const newCount = invoice.reminderCount + 1;
+      const nextDate = computeNextReminderDate(invoice.dueDate, newCount, schedule);
+
+      // Atomic update: count + nextDate in the same write — prevents reminder loops
+      await prisma.$transaction([
+        prisma.invoice.update({
+          where: { id: invoice.id },
+          data: {
+            reminderCount: newCount,
+            lastReminderSentAt: now,
+            nextReminderAt: nextDate, // null when ladder is exhausted
+          },
+        }),
+        prisma.activityLog.create({
+          data: {
+            invoiceId: invoice.id,
+            userId: invoice.userId,
+            action: isFinal ? 'mise_en_demeure_sent' : 'reminder_sent',
+            metadata: {
+              auto: true,
+              reminderCount: newCount,
+              daysOverdue,
+              clientEmail,
+              nextReminderAt: nextDate?.toISOString() ?? null,
+              isMiseEnDemeure: isFinal,
+            },
+          },
+        }),
+      ]);
+
+      sent++;
+    } catch (err: any) {
+      errors.push(`${invoice.invoiceNumber}: ${err?.message ?? String(err)}`);
+    }
+  }
+
+  console.log(`[payment-reminders] sent=${sent} skipped=${skipped} errors=${errors.length}`);
+
+  return NextResponse.json({
+    processed: invoices.length,
+    sent,
+    skipped,
+    errors,
+  });
+}

--- a/src/app/api/invoices/[invoiceId]/issue/route.tsx
+++ b/src/app/api/invoices/[invoiceId]/issue/route.tsx
@@ -10,6 +10,7 @@ import { evaluateInvoiceReadiness } from '@/domains/invoices/invoice-readiness';
 import { generateFacturxDocument } from '@/domains/invoices/facturx';
 import { logActivity } from '@/domains/invoices/activity-log';
 import { sendInvoiceEmail } from '@/lib/email-service';
+import { computeNextReminderDate, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
 
 
 const safeToNumber = (value: unknown) => {
@@ -53,10 +54,16 @@ export async function POST(
   const { invoiceId } = await params;
 
   try {
-    const invoice = await prisma.invoice.findFirst({
-      where: { id: invoiceId, userId: session.user.id },
-      include: { client: true, items: true },
-    });
+    const [invoice, issuer] = await Promise.all([
+      prisma.invoice.findFirst({
+        where: { id: invoiceId, userId: session.user.id },
+        include: { client: true, items: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { reminderEnabled: true, reminderSchedule: true },
+      }),
+    ]);
 
     if (!invoice) {
       return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
@@ -215,6 +222,12 @@ export async function POST(
       }
     }
 
+    // Compute first reminder date from user's schedule (resets on issuance)
+    const reminderSchedule = parseReminderSchedule(issuer?.reminderSchedule);
+    const nextReminderAt = issuer?.reminderEnabled !== false && invoice.reminderEnabled
+      ? computeNextReminderDate(invoice.dueDate, 0, reminderSchedule)
+      : null;
+
     const updatedInvoice = await prisma.invoice.update({
       where: { id: invoice.id },
       data: {
@@ -227,6 +240,8 @@ export async function POST(
         facturxStatus: 'generated',
         facturxGeneratedAt: new Date(),
         facturxValidationErrors: [],
+        reminderCount: 0,
+        nextReminderAt,
       },
       include: { client: true, items: true },
     });

--- a/src/app/api/invoices/[invoiceId]/reminders/route.ts
+++ b/src/app/api/invoices/[invoiceId]/reminders/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+import { computeNextReminderDate, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
+
+// PATCH /api/invoices/[invoiceId]/reminders
+// Enable or disable auto-reminders for a specific invoice.
+// Body: { enabled: boolean }
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ invoiceId: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { invoiceId } = await params;
+  const body = await req.json();
+  const enabled = Boolean(body.enabled);
+
+  const [invoice, user] = await Promise.all([
+    prisma.invoice.findFirst({
+      where: { id: invoiceId, userId: session.user.id },
+      select: { id: true, dueDate: true, reminderCount: true, paymentStatus: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { reminderSchedule: true },
+    }),
+  ]);
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
+  }
+
+  if (invoice.paymentStatus === 'paid') {
+    return NextResponse.json({ error: 'Cannot modify reminders on a paid invoice.' }, { status: 400 });
+  }
+
+  // When re-enabling, recompute next date from current count (don't restart from 0)
+  const nextReminderAt = enabled
+    ? computeNextReminderDate(
+        invoice.dueDate,
+        invoice.reminderCount,
+        parseReminderSchedule(user?.reminderSchedule)
+      )
+    : null;
+
+  const updated = await prisma.invoice.update({
+    where: { id: invoice.id },
+    data: { reminderEnabled: enabled, nextReminderAt },
+    select: { id: true, reminderEnabled: true, nextReminderAt: true },
+  });
+
+  return NextResponse.json(updated);
+}

--- a/src/app/api/invoices/[invoiceId]/route.ts
+++ b/src/app/api/invoices/[invoiceId]/route.ts
@@ -93,8 +93,17 @@ export async function PATCH(
       data: {
         ...editableFields,
         paymentStatus: body.paymentStatus,
-        // If marking as paid, also update status
-        ...(body.paymentStatus === 'paid' && { status: 'paid' }),
+        // If marking as paid: update status and kill the reminder ladder
+        ...(body.paymentStatus === 'paid' && {
+          status: 'paid',
+          nextReminderAt: null,
+          reminderEnabled: false,
+        }),
+        // If un-marking as paid: re-enable reminders but don't auto-restart ladder
+        // (user can manually send if needed)
+        ...(body.paymentStatus === 'pending' && {
+          reminderEnabled: true,
+        }),
       },
       include: {
         client: true,

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -6,6 +6,7 @@ import { authOptions } from '@/lib/auth-options';
 import { getLegalMentionsByFiscalRegime } from '@/lib/utils';
 import { evaluateInvoiceReadiness } from '@/domains/invoices/invoice-readiness';
 import { getUserPlan, getMonthlyInvoiceCount, FREE_INVOICE_LIMIT } from '@/lib/subscription';
+import { computeNextReminderDate, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
 
 const invoiceSchema = z.object({
   clientId: z.string(),
@@ -60,7 +61,7 @@ export async function POST(req: NextRequest) {
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { name: true, siret: true, tvaNumber: true, fiscalRegime: true, address: true, legalStatus: true, rcsNumber: true, shareCapital: true, apeCode: true, microEntrepreneurType: true },
+    select: { name: true, siret: true, tvaNumber: true, fiscalRegime: true, address: true, legalStatus: true, rcsNumber: true, shareCapital: true, apeCode: true, microEntrepreneurType: true, reminderEnabled: true, reminderSchedule: true },
   });
 
   // Completeness Check for Micro-Entrepreneurs
@@ -202,6 +203,14 @@ export async function POST(req: NextRequest) {
         latePenaltyRate: latePenaltyRate || "3 fois le taux d'intérêt légal",
         recoveryIndemnity: recoveryIndemnity || 40.0,
         legalMentions,
+        // Pre-schedule first reminder based on user's ladder
+        nextReminderAt: user?.reminderEnabled !== false
+          ? computeNextReminderDate(
+              new Date(dueDate),
+              0,
+              parseReminderSchedule(user?.reminderSchedule)
+            )
+          : null,
         items: {
           create: items.map(item => ({
             description: item.description,

--- a/src/app/api/settings/reminders/route.ts
+++ b/src/app/api/settings/reminders/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { prisma } from '@/lib/prisma';
+import { DEFAULT_REMINDER_SCHEDULE, parseReminderSchedule } from '@/domains/invoices/reminder-schedule';
+import { Prisma } from '@prisma/client';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { reminderEnabled: true, reminderSchedule: true },
+  });
+
+  return NextResponse.json({
+    enabled: user?.reminderEnabled ?? true,
+    schedule: parseReminderSchedule(user?.reminderSchedule),
+    isCustom: Array.isArray(user?.reminderSchedule) && (user.reminderSchedule as unknown[]).length > 0,
+  });
+}
+
+export async function PATCH(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+
+  const data: Prisma.UserUpdateInput = {};
+
+  if (typeof body.enabled === 'boolean') {
+    data.reminderEnabled = body.enabled;
+  }
+
+  if (body.schedule === null) {
+    data.reminderSchedule = Prisma.DbNull;
+  } else if (Array.isArray(body.schedule)) {
+    const parsed = parseReminderSchedule(body.schedule);
+    data.reminderSchedule = parsed as unknown as Prisma.InputJsonValue;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: 'No valid fields to update.' }, { status: 400 });
+  }
+
+  const updated = await prisma.user.update({
+    where: { id: session.user.id },
+    data,
+    select: { reminderEnabled: true, reminderSchedule: true },
+  });
+
+  return NextResponse.json({
+    enabled: updated.reminderEnabled,
+    schedule: parseReminderSchedule(updated.reminderSchedule),
+    isCustom: Array.isArray(updated.reminderSchedule) && (updated.reminderSchedule as unknown[]).length > 0,
+    defaultSchedule: DEFAULT_REMINDER_SCHEDULE,
+  });
+}

--- a/src/app/dashboard/invoices/[invoiceId]/page.tsx
+++ b/src/app/dashboard/invoices/[invoiceId]/page.tsx
@@ -58,6 +58,19 @@ type InvoiceDetail = {
   issuerLegalStatus?: string | null;
   issuerShareCapital?: string | null;
   issuerApeCode?: string | null;
+  btpInvoiceType?: string | null;
+  retenueGarantieRate?: number | string | null;
+  retenueGarantieAmount?: number | string | null;
+  situationNumber?: number | null;
+  referenceContract?: string | null;
+  previousCumulativeAmount?: number | string | null;
+  previousInvoiceNumber?: string | null;
+  codeService?: string | null;
+  numeroEngagement?: string | null;
+  reminderEnabled?: boolean;
+  reminderCount?: number;
+  nextReminderAt?: string | null;
+  lastReminderSentAt?: string | null;
 };
 
 const formatCurrency = (value: unknown) => {
@@ -205,6 +218,7 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
   const [preflightLoading, setPreflightLoading] = useState(false);
   const [sendingReminder, setSendingReminder] = useState(false);
   const [reminderSent, setReminderSent] = useState(false);
+  const [togglingReminder, setTogglingReminder] = useState(false);
   const [stripeConnected, setStripeConnected] = useState(false);
   const [isPro, setIsPro] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -696,6 +710,114 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
           </div>
           )}
 
+          {/* BTP card — shown when invoice has a BTP type */}
+          {invoice.btpInvoiceType && invoice.btpInvoiceType !== 'standard' && (
+            <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
+              <h2 className="h5 mb-3">
+                <i className="bi bi-building-gear me-2 text-primary"></i>BTP
+              </h2>
+              <div className="vstack gap-2 small">
+                <div className="d-flex justify-content-between">
+                  <span className="text-muted">Type</span>
+                  <span className="fw-semibold">
+                    {invoice.btpInvoiceType === 'autoliquidation'
+                      ? 'Autoliquidation TVA'
+                      : 'Facture de situation'}
+                  </span>
+                </div>
+                {invoice.btpInvoiceType === 'autoliquidation' && (
+                  <div className="alert alert-warning py-2 mb-0" style={{ fontSize: '0.75rem' }}>
+                    TVA autoliquidée — art. 283, 2 nonies CGI
+                  </div>
+                )}
+                {invoice.btpInvoiceType === 'situation' && (
+                  <>
+                    {invoice.situationNumber != null && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">N° de situation</span>
+                        <span>{invoice.situationNumber}</span>
+                      </div>
+                    )}
+                    {invoice.referenceContract && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Réf. contrat</span>
+                        <span className="text-truncate ms-3" style={{ maxWidth: 160 }}>{invoice.referenceContract}</span>
+                      </div>
+                    )}
+                    {invoice.previousInvoiceNumber && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Facture précédente</span>
+                        <span>{invoice.previousInvoiceNumber}</span>
+                      </div>
+                    )}
+                    {invoice.previousCumulativeAmount != null && Number(invoice.previousCumulativeAmount) > 0 && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Cumul précédent</span>
+                        <span>{formatCurrency(invoice.previousCumulativeAmount)}</span>
+                      </div>
+                    )}
+                  </>
+                )}
+                {invoice.retenueGarantieAmount != null && Number(invoice.retenueGarantieAmount) > 0 && (
+                  <>
+                    <hr className="my-1" />
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Retenue de garantie</span>
+                      <span className="text-warning fw-semibold">
+                        {invoice.retenueGarantieRate
+                          ? `${Number(invoice.retenueGarantieRate) * 100} %`
+                          : ''} — {formatCurrency(invoice.retenueGarantieAmount)}
+                      </span>
+                    </div>
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Net à payer</span>
+                      <span className="fw-semibold text-primary">
+                        {formatCurrency(Number(invoice.totalAmount) - Number(invoice.retenueGarantieAmount))}
+                      </span>
+                    </div>
+                  </>
+                )}
+                {/* B2G Chorus Pro routing — shown when codeService or numeroEngagement is set */}
+                {(invoice.codeService || invoice.numeroEngagement) && (
+                  <>
+                    <hr className="my-1" />
+                    <div className="text-muted fw-semibold" style={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                      Routage Chorus Pro
+                    </div>
+                    {invoice.codeService && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Code Service</span>
+                        <span className="font-monospace">{invoice.codeService}</span>
+                      </div>
+                    )}
+                    {!invoice.codeService && invoice.transactionType === 'B2G' && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">Code Service</span>
+                        <span className="text-danger small"><i className="bi bi-exclamation-triangle me-1"></i>Manquant</span>
+                      </div>
+                    )}
+                    {invoice.numeroEngagement && (
+                      <div className="d-flex justify-content-between">
+                        <span className="text-muted">N° Engagement</span>
+                        <span className="font-monospace">{invoice.numeroEngagement}</span>
+                      </div>
+                    )}
+                  </>
+                )}
+                {/* Show B2G routing section even when both fields are empty, for B2G invoices */}
+                {!invoice.codeService && !invoice.numeroEngagement && invoice.transactionType === 'B2G' && (
+                  <>
+                    <hr className="my-1" />
+                    <div className="alert alert-warning py-2 mb-0 small">
+                      <i className="bi bi-exclamation-triangle me-1"></i>
+                      Code Service manquant — requis pour le dépôt Chorus Pro.
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
           <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
             <h2 className="h5 mb-3">Sortie Factur-X</h2>
             <div className="d-flex justify-content-between align-items-center mb-3">
@@ -890,6 +1012,73 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
             )}
           </div>
 
+          {/* Auto-reminder status card — only shown on issued, unpaid invoices */}
+          {invoice.workflowStatus === 'issued' && invoice.paymentStatus !== 'paid' && (
+            <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
+              <div className="d-flex justify-content-between align-items-center mb-3">
+                <h2 className="h5 mb-0">
+                  <i className="bi bi-bell me-2 text-primary"></i>Relances automatiques
+                </h2>
+                <div className="form-check form-switch mb-0">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    role="switch"
+                    id="invoiceReminderToggle"
+                    checked={invoice.reminderEnabled ?? true}
+                    disabled={togglingReminder}
+                    onChange={async (e) => {
+                      setTogglingReminder(true);
+                      try {
+                        const res = await fetch(`/api/invoices/${invoiceId}/reminders`, {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ enabled: e.target.checked }),
+                        });
+                        if (res.ok) {
+                          const data = await res.json();
+                          setInvoice((prev) => prev ? { ...prev, reminderEnabled: data.reminderEnabled, nextReminderAt: data.nextReminderAt } : prev);
+                        }
+                      } finally {
+                        setTogglingReminder(false);
+                      }
+                    }}
+                  />
+                  <label className="form-check-label visually-hidden" htmlFor="invoiceReminderToggle">Activer</label>
+                </div>
+              </div>
+
+              {invoice.reminderEnabled ? (
+                <div className="vstack gap-2 small">
+                  {invoice.nextReminderAt ? (
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Prochain rappel</span>
+                      <span className="fw-semibold">
+                        {new Date(invoice.nextReminderAt).toLocaleDateString('fr-FR')}
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="text-muted">Calendrier de relance épuisé.</div>
+                  )}
+                  {invoice.reminderCount !== undefined && invoice.reminderCount > 0 && (
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Rappels envoyés</span>
+                      <span>{invoice.reminderCount}</span>
+                    </div>
+                  )}
+                  {invoice.lastReminderSentAt && (
+                    <div className="d-flex justify-content-between">
+                      <span className="text-muted">Dernier envoi</span>
+                      <span>{new Date(invoice.lastReminderSentAt).toLocaleDateString('fr-FR')}</span>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="text-muted small">Les relances automatiques sont désactivées pour cette facture.</div>
+              )}
+            </div>
+          )}
+
           <div className="card border-0 shadow-sm rounded-xl p-4 mb-4">
             <h2 className="h5 mb-3">Client</h2>
             <div className="mb-2 fw-semibold">{invoice.client?.name || invoice.clientName || 'Client non renseigné'}</div>
@@ -918,7 +1107,11 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
                       style={{
                         width: 10, height: 10,
                         borderRadius: '50%',
-                        background: log.action === 'issued' ? '#198754' : log.action === 'blocked' ? '#dc3545' : '#6c757d',
+                        background: log.action === 'issued' ? '#198754'
+                        : log.action === 'blocked' ? '#dc3545'
+                        : log.action === 'mise_en_demeure_sent' ? '#7f1d1d'
+                        : log.action === 'reminder_sent' ? '#0d6efd'
+                        : '#6c757d',
                         position: 'absolute', left: '-1.4rem', top: 4,
                       }}
                     />
@@ -926,11 +1119,17 @@ export default function InvoiceDetailPage({ params: paramsPromise }: { params: P
                       {log.action === 'issued' && '✓ Facture émise'}
                       {log.action === 'blocked' && '⚠ Facture bloquée'}
                       {log.action === 'exception_resolved' && '↩ Exception résolue'}
-                      {log.action === 'reminder_sent' && '📧 Rappel envoyé'}
+                      {log.action === 'reminder_sent' && (
+                        log.metadata?.auto
+                          ? '📧 Rappel automatique envoyé'
+                          : '📧 Rappel envoyé (manuel)'
+                      )}
+                      {log.action === 'mise_en_demeure_sent' && '⚖ Mise en demeure envoyée'}
                       {log.action === 'facturx_generated' && '✓ Factur-X généré'}
                       {log.action === 'facturx_failed' && '✗ Génération Factur-X échouée'}
                       {log.action === 'workflow_updated' && '→ Workflow mis à jour'}
                       {log.action === 'readiness_changed' && '→ Readiness modifiée'}
+                      {!['issued','blocked','exception_resolved','reminder_sent','mise_en_demeure_sent','facturx_generated','facturx_failed','workflow_updated','readiness_changed'].includes(log.action) && `→ ${log.action}`}
                     </div>
                     <div className="text-muted" style={{ fontSize: '0.75rem' }}>
                       {log.user?.name || log.user?.email || 'Système'} — {new Date(log.createdAt).toLocaleDateString('fr-FR')} {new Date(log.createdAt).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -55,6 +55,10 @@ export default function DashboardPage() {
           acc.received += amount;
         } else {
           acc.pending += amount;
+          // Outstanding = issued invoices that are unpaid (money actually owed)
+          if (invoice.workflowStatus === 'issued') {
+            acc.outstanding += amount;
+          }
         }
 
         if (invoice.status === "draft") {
@@ -64,6 +68,9 @@ export default function DashboardPage() {
         const dueDate = new Date(invoice.dueDate);
         if (invoice.paymentStatus !== "paid" && dueDate < today) {
           acc.overdue += 1;
+          if (invoice.workflowStatus === 'issued') {
+            acc.overdueAmount += amount;
+          }
         }
 
         if (invoice.paymentStatus !== "paid" && dueDate >= today && dueDate <= inSevenDays) {
@@ -77,7 +84,7 @@ export default function DashboardPage() {
 
         return acc;
       },
-      { total: 0, received: 0, pending: 0, drafts: 0, overdue: 0, dueSoon: 0, pendingPpf: 0 }
+      { total: 0, received: 0, pending: 0, outstanding: 0, overdueAmount: 0, drafts: 0, overdue: 0, dueSoon: 0, pendingPpf: 0 }
     );
   }, [allInvoices]);
 
@@ -192,8 +199,14 @@ export default function DashboardPage() {
         </div>
         <div className="col-lg-3 col-md-6">
           <div className="card h-100 p-4 stat-card-warning">
-            <div className="section-label mb-2">En attente</div>
-            <div className="metric-value text-warning">{formatCurrency(metrics.pending)}</div>
+            <div className="section-label mb-2">Créances en cours</div>
+            <div className="metric-value text-warning">{formatCurrency(metrics.outstanding)}</div>
+            {metrics.overdueAmount > 0 && (
+              <div className="text-danger small mt-1">
+                <i className="bi bi-exclamation-triangle-fill me-1"></i>
+                {formatCurrency(metrics.overdueAmount)} en retard
+              </div>
+            )}
           </div>
         </div>
         <div className="col-lg-3 col-md-6">

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -3,6 +3,8 @@
 import { Suspense, useState, useEffect, useCallback } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import type { ReminderStep } from '@/domains/invoices/reminder-schedule';
+import { DEFAULT_REMINDER_SCHEDULE } from '@/domains/invoices/reminder-schedule';
 
 // Form-state shape: all strings (empty string = unset), not nullable
 interface ProfileFormData {
@@ -52,6 +54,13 @@ function SettingsPageInner() {
   const [stripeInvoices, setStripeInvoices] = useState<StripeInvoiceItem[]>([]);
   const [invoicesLoading, setInvoicesLoading] = useState(false);
 
+  // Auto-reminders
+  const [reminderEnabled, setReminderEnabled] = useState(true);
+  const [reminderSchedule, setReminderSchedule] = useState<ReminderStep[]>(DEFAULT_REMINDER_SCHEDULE);
+  const [reminderCustom, setReminderCustom] = useState(false);
+  const [reminderSaving, setReminderSaving] = useState(false);
+  const [reminderMessage, setReminderMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
   // Chorus Pro / PISTE credentials
   const [pisteForm, setPisteForm] = useState({
     pisteEnv: 'sandbox',
@@ -72,6 +81,7 @@ function SettingsPageInner() {
       fetchProfile();
       fetchPisteCredentials();
       fetchSubscription();
+      fetchReminders();
     }
   }, [status, router]);
 
@@ -164,6 +174,48 @@ function SettingsPageInner() {
       // silently ignore fetch error — form will be empty
     } finally {
       setProfileLoading(false);
+    }
+  };
+
+  const fetchReminders = async () => {
+    try {
+      const res = await fetch('/api/settings/reminders');
+      if (res.ok) {
+        const data = await res.json();
+        setReminderEnabled(data.enabled ?? true);
+        setReminderSchedule(data.schedule ?? DEFAULT_REMINDER_SCHEDULE);
+        setReminderCustom(data.isCustom ?? false);
+      }
+    } catch { /* ignore */ }
+  };
+
+  const handleReminderSave = async (opts: { enabled?: boolean; schedule?: ReminderStep[] | null }) => {
+    setReminderSaving(true);
+    setReminderMessage(null);
+    try {
+      const body: Record<string, unknown> = {};
+      if (opts.enabled !== undefined) body.enabled = opts.enabled;
+      if (opts.schedule !== undefined) body.schedule = opts.schedule;
+
+      const res = await fetch('/api/settings/reminders', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setReminderEnabled(data.enabled ?? true);
+        setReminderSchedule(data.schedule ?? DEFAULT_REMINDER_SCHEDULE);
+        setReminderCustom(data.isCustom ?? false);
+        setReminderMessage({ type: 'success', text: 'Préférences de relance enregistrées.' });
+      } else {
+        const err = await res.json().catch(() => ({})) as { error?: string };
+        setReminderMessage({ type: 'error', text: err.error ?? 'Erreur lors de la sauvegarde.' });
+      }
+    } catch {
+      setReminderMessage({ type: 'error', text: 'Erreur réseau.' });
+    } finally {
+      setReminderSaving(false);
     }
   };
 
@@ -855,6 +907,121 @@ function SettingsPageInner() {
               </div>
             </div>
           )}
+
+          {/* ── Auto-reminders ───────────────────────────────── */}
+          <div className="card mb-4 shadow-sm">
+            <div className="card-header bg-white">
+              <h5 className="mb-0 fw-semibold">
+                <i className="bi bi-bell me-2 text-primary"></i>
+                Relances automatiques
+              </h5>
+              <small className="text-muted">InvoiceOps envoie des rappels de paiement à vos clients selon votre calendrier.</small>
+            </div>
+            <div className="card-body">
+              {reminderMessage && (
+                <div className={`alert alert-${reminderMessage.type === 'success' ? 'success' : 'danger'} alert-dismissible`}>
+                  {reminderMessage.text}
+                  <button type="button" className="btn-close" onClick={() => setReminderMessage(null)}></button>
+                </div>
+              )}
+
+              {/* Global toggle */}
+              <div className="d-flex align-items-center justify-content-between py-2 mb-4 border-bottom">
+                <div>
+                  <div className="fw-medium">Activer les relances automatiques</div>
+                  <small className="text-muted">
+                    {reminderEnabled
+                      ? 'Les rappels de paiement sont envoyés automatiquement selon le calendrier ci-dessous.'
+                      : 'Les relances automatiques sont désactivées pour toutes vos factures.'}
+                  </small>
+                </div>
+                <div className="form-check form-switch ms-3 mb-0" style={{ fontSize: '1.3rem' }}>
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    role="switch"
+                    id="reminderGlobalToggle"
+                    checked={reminderEnabled}
+                    disabled={reminderSaving}
+                    onChange={(e) => {
+                      setReminderEnabled(e.target.checked);
+                      void handleReminderSave({ enabled: e.target.checked });
+                    }}
+                  />
+                  <label className="form-check-label visually-hidden" htmlFor="reminderGlobalToggle">Activer</label>
+                </div>
+              </div>
+
+              {/* Schedule editor */}
+              <div className={reminderEnabled ? '' : 'opacity-50 pe-none'}>
+                <div className="d-flex align-items-center justify-content-between mb-2">
+                  <div className="fw-medium small text-muted" style={{ textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                    Calendrier des relances
+                  </div>
+                  {reminderCustom && (
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-link text-muted p-0"
+                      disabled={reminderSaving}
+                      onClick={() => void handleReminderSave({ schedule: null })}
+                    >
+                      <i className="bi bi-arrow-counterclockwise me-1"></i>Restaurer le calendrier par défaut
+                    </button>
+                  )}
+                </div>
+
+                <div className="list-group list-group-flush mb-3">
+                  {reminderSchedule.map((step, idx) => (
+                    <div key={idx} className="list-group-item px-0 py-2 d-flex align-items-center gap-2">
+                      <span className="badge bg-light text-dark border fw-normal" style={{ minWidth: 90, textAlign: 'center' }}>
+                        {step.triggerDays < 0
+                          ? `J${step.triggerDays} avant`
+                          : step.triggerDays === 0
+                          ? "Jour J (échéance)"
+                          : `J+${step.triggerDays} après`}
+                      </span>
+                      <input
+                        type="text"
+                        className="form-control form-control-sm"
+                        value={step.label}
+                        disabled={reminderSaving}
+                        onChange={(e) => {
+                          const updated = reminderSchedule.map((s, i) =>
+                            i === idx ? { ...s, label: e.target.value } : s
+                          );
+                          setReminderSchedule(updated);
+                          setReminderCustom(true);
+                        }}
+                      />
+                      {idx === reminderSchedule.length - 1 && (
+                        <span className="badge bg-danger-subtle text-danger border border-danger-subtle small">
+                          Mise en demeure
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="d-flex gap-2">
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-sm"
+                    disabled={reminderSaving}
+                    onClick={() => void handleReminderSave({ schedule: reminderSchedule })}
+                  >
+                    {reminderSaving
+                      ? <><span className="spinner-border spinner-border-sm me-2" />Enregistrement…</>
+                      : <><i className="bi bi-check-lg me-2" />Enregistrer le calendrier</>}
+                  </button>
+                </div>
+
+                <div className="alert alert-light border mt-3 small">
+                  <i className="bi bi-info-circle me-1 text-primary" />
+                  Les relances s'arrêtent automatiquement dès que la facture est marquée payée. La mise en demeure (dernière étape) constitue un courrier légal au sens de l'art. 1344 du Code civil.
+                </div>
+              </div>
+            </div>
+          </div>
 
         </div>
       </div>

--- a/src/domains/invoices/reminder-schedule.ts
+++ b/src/domains/invoices/reminder-schedule.ts
@@ -1,0 +1,53 @@
+export interface ReminderStep {
+  triggerDays: number; // negative = before due date, positive = days overdue
+  label: string;
+}
+
+// Applied to all users unless they override via reminderSchedule on User
+export const DEFAULT_REMINDER_SCHEDULE: ReminderStep[] = [
+  { triggerDays: -7, label: 'J-7 avant échéance' },
+  { triggerDays: 0,  label: "Jour d'échéance" },
+  { triggerDays: 3,  label: 'J+3' },
+  { triggerDays: 7,  label: 'J+7' },
+  { triggerDays: 14, label: 'J+14' },
+  { triggerDays: 30, label: 'Mise en demeure (J+30)' },
+];
+
+/**
+ * Returns the Date on which the next reminder should fire.
+ * reminderCount is the number of reminders already sent (0-based index into schedule).
+ * Returns null when the ladder is exhausted.
+ */
+export function computeNextReminderDate(
+  dueDate: Date,
+  reminderCount: number,
+  schedule: ReminderStep[] = DEFAULT_REMINDER_SCHEDULE
+): Date | null {
+  const step = schedule[reminderCount];
+  if (!step) return null;
+  const d = new Date(dueDate);
+  d.setDate(d.getDate() + step.triggerDays);
+  // Normalize to start of day UTC to avoid time-of-day drift across cron runs
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Returns true when reminderCount has reached the last step of the schedule
+ * (i.e. the upcoming reminder is the Mise en Demeure).
+ */
+export function isLastReminder(
+  reminderCount: number,
+  schedule: ReminderStep[] = DEFAULT_REMINDER_SCHEDULE
+): boolean {
+  return reminderCount === schedule.length - 1;
+}
+
+/** Safe parse of a user's custom reminderSchedule JSON — falls back to default. */
+export function parseReminderSchedule(raw: unknown): ReminderStep[] {
+  if (!Array.isArray(raw) || raw.length === 0) return DEFAULT_REMINDER_SCHEDULE;
+  const parsed = (raw as any[]).filter(
+    (s) => typeof s.triggerDays === 'number' && typeof s.label === 'string'
+  );
+  return parsed.length > 0 ? parsed : DEFAULT_REMINDER_SCHEDULE;
+}

--- a/src/lib/email-service.ts
+++ b/src/lib/email-service.ts
@@ -57,6 +57,8 @@ export interface SendReminderEmailParams {
   totalAmount: number;
   dueDate: Date | string;
   daysOverdue?: number;
+  reminderCount?: number;  // 0-based: determines tone escalation
+  isMiseEnDemeure?: boolean;
 }
 
 function formatAmount(amount: number) {
@@ -112,39 +114,72 @@ export async function sendInvoiceEmail(params: SendInvoiceEmailParams) {
 }
 
 export async function sendReminderEmail(params: SendReminderEmailParams) {
-  const { to, clientName, issuerName, invoiceNumber, totalAmount, dueDate, daysOverdue } = params;
+  const { to, clientName, issuerName, invoiceNumber, totalAmount, dueDate, daysOverdue, reminderCount = 0, isMiseEnDemeure = false } = params;
 
-  const urgency = daysOverdue && daysOverdue > 0
-    ? `<p style="color:#dc2626;font-weight:600">Cette facture est en retard de ${daysOverdue} jour(s).</p>`
-    : `<p style="color:#d97706">Cette facture arrive à échéance le <strong>${formatDate(dueDate)}</strong>.</p>`;
+  // Escalating tone by step in the reminder ladder
+  let headerColor: string;
+  let greeting: string;
+  let bodyText: string;
+
+  if (isMiseEnDemeure) {
+    headerColor = '#7f1d1d';
+    greeting = `Madame, Monsieur,`;
+    bodyText = `Par la présente, nous vous mettons en demeure de procéder au règlement de la facture <strong>${invoiceNumber}</strong> établie par <strong>${issuerName}</strong>, dont le montant reste impayé à ce jour.
+      À défaut de règlement dans les 8 jours suivant la réception de ce courrier, nous nous réserverons le droit d'engager toute procédure de recouvrement, notamment devant le Tribunal de Commerce compétent, ainsi que de réclamer les intérêts de retard au taux légal majoré conformément à l'article L.441-10 du Code de commerce.`;
+  } else if (reminderCount >= 2) {
+    headerColor = '#dc2626';
+    greeting = `Bonjour ${clientName},`;
+    bodyText = `Nous constatons que la facture <strong>${invoiceNumber}</strong> de <strong>${issuerName}</strong>, arrivée à échéance le <strong>${formatDate(dueDate)}</strong>, reste à ce jour impayée. Nous vous demandons de bien vouloir régulariser votre situation dans les meilleurs délais afin d'éviter des frais supplémentaires.`;
+  } else if (reminderCount === 1) {
+    headerColor = '#d97706';
+    greeting = `Bonjour ${clientName},`;
+    bodyText = `Sauf erreur de notre part, la facture <strong>${invoiceNumber}</strong> de <strong>${issuerName}</strong> n'a toujours pas été réglée. Pourriez-vous nous confirmer la date de paiement prévue ?`;
+  } else {
+    headerColor = '#2563eb';
+    greeting = `Bonjour ${clientName},`;
+    bodyText = `Nous vous rappelons que la facture <strong>${invoiceNumber}</strong> de <strong>${issuerName}</strong> arrive bientôt à échéance. N'hésitez pas à nous contacter si vous avez la moindre question.`;
+  }
+
+  const urgencyLine = daysOverdue && daysOverdue > 0
+    ? `<p style="color:#dc2626;font-weight:600">Cette facture accuse un retard de ${daysOverdue} jour(s).</p>`
+    : `<p style="color:#d97706">Échéance : <strong>${formatDate(dueDate)}</strong></p>`;
+
+  const miseEnDemeureBanner = isMiseEnDemeure
+    ? `<div style="background:#7f1d1d;color:#fff;padding:12px 16px;border-radius:6px;margin-bottom:20px;font-weight:700;font-size:15px;letter-spacing:0.5px">MISE EN DEMEURE</div>`
+    : '';
 
   const html = `
     <div style="font-family:sans-serif;max-width:600px;margin:0 auto;color:#111">
-      <h2 style="color:#d97706">Rappel de paiement — ${invoiceNumber}</h2>
-      <p>Bonjour ${clientName},</p>
-      <p>Nous vous rappelons que la facture <strong>${invoiceNumber}</strong> de <strong>${issuerName}</strong> est en attente de règlement.</p>
-      ${urgency}
+      ${miseEnDemeureBanner}
+      <h2 style="color:${headerColor}">${isMiseEnDemeure ? `Mise en Demeure — ${invoiceNumber}` : `Rappel de paiement — ${invoiceNumber}`}</h2>
+      <p>${greeting}</p>
+      <p>${bodyText}</p>
+      ${!isMiseEnDemeure ? urgencyLine : ''}
       <table style="border-collapse:collapse;width:100%;margin:16px 0">
         <tr style="background:#f3f4f6">
           <td style="padding:10px 14px">Montant dû</td>
           <td style="padding:10px 14px;font-weight:600;text-align:right">${formatAmount(totalAmount)}</td>
         </tr>
         <tr>
-          <td style="padding:10px 14px">Date d'échéance</td>
+          <td style="padding:10px 14px">Date d'échéance initiale</td>
           <td style="padding:10px 14px;text-align:right">${formatDate(dueDate)}</td>
         </tr>
+        ${daysOverdue && daysOverdue > 0 ? `<tr style="background:#fef2f2"><td style="padding:10px 14px;color:#dc2626">Retard</td><td style="padding:10px 14px;text-align:right;color:#dc2626;font-weight:600">${daysOverdue} jour(s)</td></tr>` : ''}
       </table>
-      <p>Si vous avez déjà effectué le règlement, veuillez ignorer ce message.</p>
+      ${isMiseEnDemeure
+        ? `<p style="font-size:13px;color:#6b7280">Ce courrier constitue une mise en demeure au sens de l'article 1344 du Code civil. Les intérêts de retard courent à compter de la date d'échéance de la facture.</p>`
+        : `<p>Si vous avez déjà effectué le règlement, veuillez ignorer ce message.</p>`}
       <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0">
       <p style="color:#6b7280;font-size:12px">${issuerName}</p>
     </div>
   `;
 
+  const subject = isMiseEnDemeure
+    ? `MISE EN DEMEURE — Facture ${invoiceNumber} — ${formatAmount(totalAmount)}`
+    : reminderCount >= 2
+    ? `[Urgent] Facture ${invoiceNumber} impayée — ${formatAmount(totalAmount)}`
+    : `Rappel — Facture ${invoiceNumber} de ${formatAmount(totalAmount)} en attente`;
+
   if (!resend) { console.warn('RESEND_API_KEY not set — reminder email skipped'); return; }
-  return resend.emails.send({
-    from: FROM,
-    to,
-    subject: `Rappel — Facture ${invoiceNumber} de ${formatAmount(totalAmount)} en attente`,
-    html,
-  });
+  return resend.emails.send({ from: FROM, to, subject, html });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,10 @@
     {
       "path": "/api/cron/notification-retries",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/payment-reminders",
+      "schedule": "0 9 * * *"
     }
   ],
   "functions": {
@@ -59,6 +63,9 @@
       "maxDuration": 60
     },
     "src/app/api/cron/ppf-status-poll/route.ts": {
+      "maxDuration": 60
+    },
+    "src/app/api/cron/payment-reminders/route.ts": {
       "maxDuration": 60
     }
   }


### PR DESCRIPTION
## Summary

- **Reminder engine (steps 1–7)**: `reminder-schedule.ts` domain with `DEFAULT_REMINDER_SCHEDULE` (J-7, J0, J+3, J+7, J+14, J+30 Mise en Demeure), `computeNextReminderDate`, `parseReminderSchedule`; cron `POST /api/cron/payment-reminders` (daily 09:00); atomic `$transaction` prevents double-firing; Mise en Demeure on final step
- **Email escalation**: tone escalates step-by-step (blue → amber → red → dark red MISE EN DEMEURE banner with art. 1344 Code civil notice)
- **Schema**: `reminderEnabled/Count/Schedule/nextReminderAt/lastReminderSentAt` on User and Invoice; `nextReminderAt` set on invoice creation and reset on issuance; cleared on mark-as-paid
- **Settings API** (`GET/PATCH /api/settings/reminders`): returns/updates global reminder toggle + custom JSON schedule; `Prisma.DbNull` for reset to default
- **Per-invoice toggle** (`PATCH /api/invoices/[id]/reminders`): enable/disable per invoice, recomputes `nextReminderAt` from current `reminderCount` when re-enabling
- **Settings UI card**: global on/off toggle (auto-saves on change), editable step list, "Restaurer le calendrier par défaut" button, Mise en Demeure legal status info alert
- **Dashboard widget**: "Créances en cours" shows outstanding total (issued + unpaid); red sub-line when overdue amount > 0
- **Invoice detail card**: reminder toggle, next reminder date, count, last sent date

## Test plan

- [ ] Issue an invoice — verify `nextReminderAt` is set based on due date + J-7 offset
- [ ] Trigger cron manually — verify reminder email sent, `reminderCount` incremented, `nextReminderAt` advanced
- [ ] Reach final step — verify `mise_en_demeure_sent` logged, `nextReminderAt = null`
- [ ] Toggle reminder off on invoice detail — verify `nextReminderAt` cleared, no further cron touches
- [ ] Toggle back on — verify `nextReminderAt` recomputed from current `reminderCount`
- [ ] Customize schedule in settings — verify custom steps persist, restore-default button appears
- [ ] Mark invoice as paid — verify `nextReminderAt` cleared
- [ ] Dashboard "Créances en cours" shows correct outstanding sum