### PR TITLE
Fix: trim env vars in LLM router (prevent Groq auth failures)

### DIFF
--- a/src/lib/llm-router.ts
+++ b/src/lib/llm-router.ts
@@ -46,7 +46,7 @@ function isFallbackWorthy(err: unknown): boolean {
 }
 
 function getProvider(envKey: string, defaultProvider: LLMProvider): LLMProvider {
-  const val = process.env[envKey]?.toLowerCase();
+  const val = process.env[envKey]?.trim().toLowerCase();
   return val === 'ollama' ? 'ollama' : val === 'groq' ? 'groq' : defaultProvider;
 }
 
@@ -64,24 +64,24 @@ export function getFallbackProvider(): LLMProvider {
 function buildClient(provider: LLMProvider): OpenAI {
   if (provider === 'ollama') {
     return new OpenAI({
-      apiKey: process.env.OLLAMA_API_KEY ?? 'ollama',
-      baseURL: process.env.OLLAMA_BASE_URL ?? 'https://ollama.com/v1',
+      apiKey: process.env.OLLAMA_API_KEY?.trim() ?? 'ollama',
+      baseURL: process.env.OLLAMA_BASE_URL?.trim() ?? 'https://ollama.com/v1',
     });
   }
   return new OpenAI({
-    apiKey: process.env.GROQ_API_KEY,
+    apiKey: process.env.GROQ_API_KEY?.trim(),
     baseURL: 'https://api.groq.com/openai/v1',
   });
 }
 
 const VISION_MODELS: Record<LLMProvider, string> = {
-  groq: process.env.GROQ_VISION_MODEL ?? 'meta-llama/llama-4-scout-17b-16e-instruct',
-  ollama: process.env.OLLAMA_VISION_MODEL ?? 'gemma3:27b',
+  groq: process.env.GROQ_VISION_MODEL?.trim() ?? 'meta-llama/llama-4-scout-17b-16e-instruct',
+  ollama: process.env.OLLAMA_VISION_MODEL?.trim() ?? 'gemma3:27b',
 };
 
 const TEXT_MODELS: Record<LLMProvider, string> = {
-  groq: process.env.GROQ_MODEL ?? 'mistral-saba-24b',
-  ollama: process.env.OLLAMA_MODEL ?? 'ministral-3:8b',
+  groq: process.env.GROQ_MODEL?.trim() ?? 'mistral-saba-24b',
+  ollama: process.env.OLLAMA_MODEL?.trim() ?? 'ministral-3:8b',
 };
 
 type ChatMessages = OpenAI.Chat.ChatCompletionMessageParam[];
@@ -227,8 +227,8 @@ export async function extractFromText(
  */
 export function isLLMConfigured(): boolean {
   const primary = getPrimaryProvider();
-  if (primary === 'groq') return !!process.env.GROQ_API_KEY;
-  return !!process.env.OLLAMA_API_KEY;
+  if (primary === 'groq') return !!process.env.GROQ_API_KEY?.trim();
+  return !!process.env.OLLAMA_API_KEY?.trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

`GROQ_API_KEY`, `OLLAMA_API_KEY`, `OLLAMA_BASE_URL`, and all model-name env vars in `llm-router.ts` were passed to the OpenAI SDK without `.trim()`. Vercel CLI and copy-paste workflows regularly introduce trailing `\n` characters — confirmed present in production env vars (`GROQ_API_KEY` has a trailing newline). This causes the Groq API to reject all requests with an auth error.

`LLM_PRIMARY` and `LLM_FALLBACK` comparison also now trims before equality check (`'groq\n' !== 'groq'` was silently falling back to the string default, which happened to be correct — but only by accident).

Follows the same `.trim()` pattern already applied to Cloudinary, PISTE, and Stripe env reads (documented in CLAUDE.md).

## Test plan
- [ ] LLM document extraction succeeds (invoice OCR / PDF parsing) — previously would fail with 401 from Groq
- [ ] `isLLMConfigured()` returns `true` when `GROQ_API_KEY` is set with a trailing newline