### PR TITLE
Feat: SEO — metadata API, sitemap.xml, robots.txt, JSON-LD

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,151 +1,54 @@
 {
-  "name": "Splitfact - Agence Créative Premium",
-  "short_name": "Splitfact",
-  "description": "Plateforme premium qui transforme les collectives créatives en agences professionnelles",
+  "name": "InvoiceOps — Facturation électronique BTP & Chorus Pro",
+  "short_name": "InvoiceOps",
+  "description": "Facturation électronique conforme Factur-X, dépôt Chorus Pro et conformité fiscale pour artisans BTP et micro-entrepreneurs français.",
   "start_url": "/dashboard",
   "display": "standalone",
-  "background_color": "#F9FAFB",
-  "theme_color": "#2563EB",
+  "background_color": "#0D1117",
+  "theme_color": "#D4921A",
   "orientation": "portrait-primary",
   "scope": "/",
-  "categories": ["business", "productivity", "design", "collaboration"],
+  "categories": ["business", "productivity", "finance"],
   "lang": "fr",
   "dir": "ltr",
   "display_override": ["window-controls-overlay", "standalone"],
   "icons": [
-    {
-      "src": "/icons/icon-72x72.png",
-      "sizes": "72x72",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-96x96.png",
-      "sizes": "96x96",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "/icons/icon-384x384.png",
-      "sizes": "384x384",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any maskable"
-    }
+    { "src": "/icons/icon-72x72.png", "sizes": "72x72", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-96x96.png", "sizes": "96x96", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-128x128.png", "sizes": "128x128", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-144x144.png", "sizes": "144x144", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-152x152.png", "sizes": "152x152", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-192x192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "/icons/icon-384x384.png", "sizes": "384x384", "type": "image/png", "purpose": "any" },
+    { "src": "/icons/icon-512x512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
   ],
   "shortcuts": [
     {
-      "name": "Projets Agence",
-      "short_name": "Projets",
-      "description": "Gérer les projets de l'agence",
-      "url": "/dashboard/projects",
-      "icons": [
-        {
-          "src": "/icons/shortcut-projects.png",
-          "sizes": "192x192",
-          "type": "image/png"
-        }
-      ]
+      "name": "Nouvelle facture",
+      "short_name": "Facture",
+      "description": "Créer une facture conforme Factur-X",
+      "url": "/dashboard/create-invoice",
+      "icons": [{ "src": "/icons/shortcut-invoice.png", "sizes": "192x192", "type": "image/png" }]
     },
     {
-      "name": "Analytics Agence",
-      "short_name": "Analytics",
-      "description": "Performance et insights agence",
-      "url": "/dashboard/analytics",
-      "icons": [
-        {
-          "src": "/icons/shortcut-analytics.png",
-          "sizes": "192x192",
-          "type": "image/png"
-        }
-      ]
-    },
-    {
-      "name": "Équipes",
-      "short_name": "Équipes",
-      "description": "Gérer les équipes créatives",
-      "url": "/dashboard/collectives",
-      "icons": [
-        {
-          "src": "/icons/shortcut-teams.png",
-          "sizes": "192x192",
-          "type": "image/png"
-        }
-      ]
-    },
-    {
-      "name": "Clients",
+      "name": "Mes clients",
       "short_name": "Clients",
-      "description": "Gérer les clients de l'agence",
+      "description": "Gérer vos clients et leurs SIRET",
       "url": "/dashboard/clients",
-      "icons": [
-        {
-          "src": "/icons/shortcut-clients.png",
-          "sizes": "192x192",
-          "type": "image/png"
-        }
-      ]
-    }
-  ],
-  "screenshots": [
-    {
-      "src": "/screenshots/desktop-dashboard.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "Dashboard agence créative"
+      "icons": [{ "src": "/icons/shortcut-clients.png", "sizes": "192x192", "type": "image/png" }]
     },
     {
-      "src": "/screenshots/mobile-dashboard.png",
-      "sizes": "390x844",
-      "type": "image/png",
-      "form_factor": "narrow",
-      "label": "Mobile agence"
+      "name": "Déclaration URSSAF",
+      "short_name": "URSSAF",
+      "description": "Générer une déclaration URSSAF",
+      "url": "/dashboard/compliance",
+      "icons": [{ "src": "/icons/shortcut-urssaf.png", "sizes": "192x192", "type": "image/png" }]
     }
   ],
   "related_applications": [],
   "prefer_related_applications": false,
-  "edge_side_panel": {
-    "preferred_width": 400
-  },
-  "launch_handler": {
-    "client_mode": "navigate-existing"
-  },
+  "edge_side_panel": { "preferred_width": 400 },
+  "launch_handler": { "client_mode": "navigate-existing" },
   "handle_links": "preferred",
-  "capture_links": "new-client",
-  "protocol_handlers": [
-    {
-      "protocol": "web+splitfact",
-      "url": "/dashboard/projects/create?via=%s"
-    }
-  ]
+  "capture_links": "new-client"
 }

--- a/src/app/ClientShell.tsx
+++ b/src/app/ClientShell.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import "bootstrap/dist/css/bootstrap.min.css";
+import "./globals.css";
+import SessionProvider from "@/app/components/SessionProvider";
+import Sidebar from "@/app/components/Sidebar";
+import Navbar from "@/app/components/Navbar";
+import DashboardNavbar from "@/app/components/DashboardNavbar";
+import { ToastProvider } from "@/app/dashboard/components/ToastProvider";
+import FixedNotificationCenter from "@/app/dashboard/components/FixedNotificationCenter";
+import FeedbackButton from "@/app/components/FeedbackButton";
+import { PWAInstallBadge } from "@/app/components/PWAInstallPrompt";
+import OfflineIndicator from "@/app/components/OfflineIndicator";
+import PWAUpdatePrompt from "@/app/components/PWAUpdatePrompt";
+import CookieBanner, { getCookieConsent } from "@/app/components/CookieBanner";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { GoogleAnalytics } from '@next/third-parties/google';
+
+export default function ClientShell({ children }: { children: React.ReactNode }) {
+  const [analyticsConsent, setAnalyticsConsent] = useState(false);
+
+  useEffect(() => {
+    setAnalyticsConsent(getCookieConsent() === 'accepted');
+    const onStorage = () => setAnalyticsConsent(getCookieConsent() === 'accepted');
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  useEffect(() => {
+    require("bootstrap/dist/js/bootstrap.bundle.min.js");
+
+    const handleSidebarShow = () => {
+      const floatingBtn = document.getElementById('floatingCloseSidebar');
+      if (floatingBtn) {
+        floatingBtn.classList.remove('d-none');
+        setTimeout(() => {
+          floatingBtn.style.opacity = '1';
+          floatingBtn.style.transform = 'translateY(-50%) scale(1)';
+        }, 100);
+      }
+    };
+
+    const handleSidebarHide = () => {
+      const floatingBtn = document.getElementById('floatingCloseSidebar');
+      if (floatingBtn) {
+        floatingBtn.style.opacity = '0';
+        floatingBtn.style.transform = 'translateY(-50%) scale(0.8)';
+        setTimeout(() => {
+          floatingBtn.classList.add('d-none');
+        }, 300);
+      }
+    };
+
+    const setupSidebarListeners = () => {
+      const sidebar = document.getElementById('mobileSidebar');
+      if (sidebar) {
+        sidebar.addEventListener('show.bs.offcanvas', handleSidebarShow);
+        sidebar.addEventListener('hide.bs.offcanvas', handleSidebarHide);
+      }
+    };
+
+    setTimeout(setupSidebarListeners, 500);
+
+    return () => {
+      const sidebar = document.getElementById('mobileSidebar');
+      if (sidebar) {
+        sidebar.removeEventListener('show.bs.offcanvas', handleSidebarShow);
+        sidebar.removeEventListener('hide.bs.offcanvas', handleSidebarHide);
+      }
+    };
+  }, []);
+
+  const pathname = usePathname();
+  const isDashboardRoute = pathname.startsWith("/dashboard");
+
+  return (
+    <>
+      <SessionProvider>
+        {isDashboardRoute ? (
+          <ToastProvider>
+            <DashboardNavbar />
+
+            <OfflineIndicator showOnlineStatus={true} />
+            <PWAUpdatePrompt />
+            <PWAInstallBadge className="d-lg-none" />
+
+            <div
+              className="offcanvas offcanvas-start mobile-sidebar-offcanvas"
+              tabIndex={-1}
+              id="mobileSidebar"
+              aria-labelledby="mobileSidebarLabel"
+              style={{ width: '280px' }}
+            >
+              <div className="offcanvas-header border-bottom">
+                <h5 className="offcanvas-title fw-bold text-primary d-flex align-items-center" id="mobileSidebarLabel">
+                  <i className="bi bi-lightning-fill me-2"></i>
+                  Menu Navigation
+                </h5>
+                <button
+                  type="button"
+                  className="btn-close mobile-close-btn"
+                  data-bs-dismiss="offcanvas"
+                  aria-label="Fermer le menu de navigation"
+                  style={{ minWidth: '32px', minHeight: '32px', borderRadius: '8px' }}
+                ></button>
+              </div>
+              <div className="offcanvas-body p-0" role="navigation" aria-label="Menu principal">
+                <Sidebar />
+              </div>
+            </div>
+
+            <div className="d-none d-lg-block">
+              <Sidebar />
+              <FixedNotificationCenter />
+
+              <div style={{ position: 'fixed', bottom: '20px', right: '20px', zIndex: 1050 }}>
+                <FeedbackButton variant="primary" size="md" className="shadow-lg" showText={true} />
+              </div>
+
+              <main
+                style={{
+                  marginLeft: '240px',
+                  padding: '2rem',
+                  minHeight: '100vh',
+                  backgroundColor: '#08090a',
+                }}
+              >
+                <div className="container-fluid" style={{ maxWidth: '1200px' }}>
+                  {children}
+                </div>
+              </main>
+            </div>
+
+            <div className="d-lg-none">
+              <FixedNotificationCenter />
+
+              <button
+                id="floatingCloseSidebar"
+                className="btn btn-primary shadow-lg d-none"
+                style={{
+                  position: 'fixed',
+                  top: '50%',
+                  right: '20px',
+                  zIndex: 1040,
+                  width: '48px',
+                  height: '48px',
+                  borderRadius: '50%',
+                  border: 'none',
+                  transform: 'translateY(-50%)',
+                  transition: 'all 0.3s ease-in-out',
+                }}
+                onClick={() => {
+                  const offcanvas = document.getElementById('mobileSidebar');
+                  if (offcanvas) {
+                    const bsOffcanvas = (window as any).bootstrap?.Offcanvas?.getInstance(offcanvas);
+                    if (bsOffcanvas) bsOffcanvas.hide();
+                  }
+                }}
+                aria-label="Fermer le menu"
+              >
+                <i className="bi bi-x" style={{ fontSize: '1.5rem' }}></i>
+              </button>
+
+              <FeedbackButton variant="floating" />
+
+              <main
+                className="container-fluid px-3 py-3"
+                style={{
+                  paddingTop: '80px',
+                  paddingBottom: '20px',
+                  minHeight: '100vh',
+                  backgroundColor: '#0D1117',
+                }}
+              >
+                {children}
+              </main>
+            </div>
+          </ToastProvider>
+        ) : (
+          <>
+            <Navbar />
+            <main>{children}</main>
+          </>
+        )}
+        <CookieBanner />
+      </SessionProvider>
+      {analyticsConsent && <GoogleAnalytics gaId="G-VNPY0RYV2B" />}
+    </>
+  );
+}

--- a/src/app/auth/register/layout.tsx
+++ b/src/app/auth/register/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Créer un compte gratuit",
+  description:
+    "Inscrivez-vous gratuitement sur InvoiceOps. 10 factures par mois offertes, conformité Factur-X et Chorus Pro incluses.",
+  alternates: { canonical: "/auth/register" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/auth/signin/layout.tsx
+++ b/src/app/auth/signin/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Connexion",
+  description: "Connectez-vous à votre compte InvoiceOps pour gérer vos factures électroniques.",
+  alternates: { canonical: "/auth/signin" },
+  robots: { index: false, follow: true },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/comment-ca-marche/layout.tsx
+++ b/src/app/comment-ca-marche/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Comment ça marche : facturation électronique BTP en 4 étapes",
+  description:
+    "Découvrez comment InvoiceOps automatise la facturation Factur-X, le dépôt Chorus Pro et la conformité BTP en 4 étapes simples : création, validation, génération PDF/A-3, dépôt PPF.",
+  alternates: { canonical: "/comment-ca-marche" },
+  openGraph: {
+    title: "Comment ça marche — InvoiceOps",
+    description:
+      "4 étapes pour émettre une facture conforme Factur-X et la déposer sur Chorus Pro sans rejet.",
+    url: "/comment-ca-marche",
+    type: "article",
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/fonctionnalites/layout.tsx
+++ b/src/app/fonctionnalites/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Fonctionnalités : Factur-X, Chorus Pro, e-reporting BTP",
+  description:
+    "Toutes les fonctionnalités d'InvoiceOps pour artisans BTP : génération Factur-X (PDF/A-3 + XML EN 16931), dépôt Chorus Pro/PPF, e-reporting B2C, validation SIRET, autoliquidation TVA, retenue de garantie, factures de situation.",
+  alternates: { canonical: "/fonctionnalites" },
+  openGraph: {
+    title: "Fonctionnalités InvoiceOps — Factur-X, Chorus Pro, e-reporting",
+    description:
+      "Liste complète des fonctionnalités pour la facturation électronique BTP conforme à la réforme française 2026.",
+    url: "/fonctionnalites",
+    type: "article",
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,251 +1,179 @@
-'use client';
+import type { Metadata, Viewport } from "next";
+import Script from "next/script";
+import ClientShell from "./ClientShell";
 
-import "bootstrap/dist/css/bootstrap.min.css";
-import "./globals.css";
-import SessionProvider from "@/app/components/SessionProvider";
-import Sidebar from "@/app/components/Sidebar";
-import Navbar from "@/app/components/Navbar";
-import DashboardNavbar from "@/app/components/DashboardNavbar";
-import { ToastProvider } from "@/app/dashboard/components/ToastProvider";
-import FixedNotificationCenter from "@/app/dashboard/components/FixedNotificationCenter";
-import FeedbackButton from "@/app/components/FeedbackButton";
-import { PWAInstallBadge } from "@/app/components/PWAInstallPrompt";
-import OfflineIndicator from "@/app/components/OfflineIndicator";
-import PWAUpdatePrompt from "@/app/components/PWAUpdatePrompt";
-import CookieBanner, { getCookieConsent } from "@/app/components/CookieBanner";
-import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
-import { GoogleAnalytics } from '@next/third-parties/google';
+const SITE_URL = "https://invoiceops.fr";
+const SITE_NAME = "InvoiceOps";
 
-export default function RootLayout({ children }: { children: React.ReactNode; }) {
-  const [analyticsConsent, setAnalyticsConsent] = useState(false);
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "InvoiceOps — Facturation électronique BTP & Chorus Pro pour micro-entrepreneurs",
+    template: "%s — InvoiceOps",
+  },
+  description:
+    "Logiciel de facturation électronique conforme Factur-X pour artisans BTP et micro-entrepreneurs : autoliquidation TVA, retenue de garantie, factures de situation, dépôt Chorus Pro/PPF, e-reporting DGFiP. Préparez la réforme 2026.",
+  keywords: [
+    "facturation électronique",
+    "Factur-X",
+    "Chorus Pro",
+    "PPF",
+    "Portail Public de Facturation",
+    "facturation BTP",
+    "autoliquidation TVA",
+    "retenue de garantie",
+    "facture de situation",
+    "micro-entrepreneur",
+    "artisan BTP",
+    "sous-traitance BTP",
+    "e-invoicing France",
+    "réforme 2026",
+    "EN 16931",
+    "URSSAF auto-entrepreneur",
+    "logiciel facture artisan",
+    "PDF/A-3",
+  ],
+  applicationName: SITE_NAME,
+  authors: [{ name: SITE_NAME, url: SITE_URL }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
+  category: "business",
+  formatDetection: { email: false, address: false, telephone: false },
+  alternates: {
+    canonical: "/",
+    languages: { "fr-FR": "/" },
+  },
+  openGraph: {
+    type: "website",
+    locale: "fr_FR",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: "InvoiceOps — Facturation électronique BTP & Chorus Pro",
+    description:
+      "Factur-X, dépôt Chorus Pro/PPF et conformité fiscale en un clic pour les artisans BTP sous-traitants. Préparez la réforme française du e-invoicing 2026.",
+    images: [
+      {
+        url: "/icons/icon-512x512.png",
+        width: 512,
+        height: 512,
+        alt: "InvoiceOps — Facturation électronique conforme",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "InvoiceOps — Facturation électronique BTP & Chorus Pro",
+    description:
+      "Factur-X, Chorus Pro et e-reporting pour artisans BTP. Conforme à la réforme française 2026.",
+    images: ["/icons/icon-512x512.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  manifest: "/manifest.json",
+  icons: {
+    icon: [
+      { url: "/favicon.png", type: "image/png" },
+      { url: "/favicon.png", sizes: "16x16", type: "image/png" },
+      { url: "/favicon.png", sizes: "32x32", type: "image/png" },
+    ],
+    shortcut: "/favicon.png",
+    apple: [
+      { url: "/icons/icon-72x72.png", sizes: "72x72" },
+      { url: "/icons/icon-96x96.png", sizes: "96x96" },
+      { url: "/icons/icon-128x128.png", sizes: "128x128" },
+      { url: "/icons/icon-144x144.png", sizes: "144x144" },
+      { url: "/icons/icon-152x152.png", sizes: "152x152" },
+      { url: "/icons/icon-192x192.png", sizes: "192x192" },
+    ],
+  },
+  appleWebApp: {
+    capable: true,
+    title: SITE_NAME,
+    statusBarStyle: "default",
+  },
+  other: {
+    "msapplication-TileColor": "#D4921A",
+    "msapplication-TileImage": "/icons/icon-144x144.png",
+    "msapplication-starturl": "/dashboard",
+    "msapplication-navbutton-color": "#D4921A",
+    "mobile-web-app-capable": "yes",
+  },
+};
 
-  useEffect(() => {
-    setAnalyticsConsent(getCookieConsent() === 'accepted');
-    const onStorage = () => setAnalyticsConsent(getCookieConsent() === 'accepted');
-    window.addEventListener('storage', onStorage);
-    return () => window.removeEventListener('storage', onStorage);
-  }, []);
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#D4921A",
+};
 
-  useEffect(() => {
-    require("bootstrap/dist/js/bootstrap.bundle.min.js");
-    
-    // Add sidebar event listeners for mobile close button
-    const handleSidebarShow = () => {
-      const floatingBtn = document.getElementById('floatingCloseSidebar');
-      if (floatingBtn) {
-        floatingBtn.classList.remove('d-none');
-        setTimeout(() => {
-          floatingBtn.style.opacity = '1';
-          floatingBtn.style.transform = 'translateY(-50%) scale(1)';
-        }, 100);
-      }
-    };
-    
-    const handleSidebarHide = () => {
-      const floatingBtn = document.getElementById('floatingCloseSidebar');
-      if (floatingBtn) {
-        floatingBtn.style.opacity = '0';
-        floatingBtn.style.transform = 'translateY(-50%) scale(0.8)';
-        setTimeout(() => {
-          floatingBtn.classList.add('d-none');
-        }, 300);
-      }
-    };
-    
-    // Set up event listeners when component mounts
-    const setupSidebarListeners = () => {
-      const sidebar = document.getElementById('mobileSidebar');
-      if (sidebar) {
-        sidebar.addEventListener('show.bs.offcanvas', handleSidebarShow);
-        sidebar.addEventListener('hide.bs.offcanvas', handleSidebarHide);
-      }
-    };
-    
-    // Delay setup to ensure DOM is ready
-    setTimeout(setupSidebarListeners, 500);
-    
-    // Cleanup
-    return () => {
-      const sidebar = document.getElementById('mobileSidebar');
-      if (sidebar) {
-        sidebar.removeEventListener('show.bs.offcanvas', handleSidebarShow);
-        sidebar.removeEventListener('hide.bs.offcanvas', handleSidebarHide);
-      }
-    };
-  }, []);
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: SITE_NAME,
+  url: SITE_URL,
+  logo: `${SITE_URL}/icons/icon-512x512.png`,
+  description:
+    "Logiciel SaaS de facturation électronique conforme Factur-X pour artisans BTP et micro-entrepreneurs en France.",
+  areaServed: { "@type": "Country", name: "France" },
+  contactPoint: {
+    "@type": "ContactPoint",
+    email: "support@invoiceops.fr",
+    contactType: "customer support",
+    availableLanguage: ["French"],
+  },
+};
 
-  const pathname = usePathname();
-  const isDashboardRoute = pathname.startsWith("/dashboard");
+const softwareSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: SITE_NAME,
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Web",
+  inLanguage: "fr-FR",
+  description:
+    "Plateforme de facturation électronique pour artisans BTP : Factur-X, Chorus Pro, autoliquidation TVA, retenue de garantie, factures de situation, e-reporting DGFiP.",
+  offers: [
+    {
+      "@type": "Offer",
+      name: "Plan Gratuit",
+      price: "0",
+      priceCurrency: "EUR",
+      description: "Jusqu'à 10 factures par mois, clients illimités, lien de paiement Stripe.",
+    },
+    {
+      "@type": "Offer",
+      name: "Plan Pro",
+      priceCurrency: "EUR",
+      description:
+        "Factures illimitées, Factur-X, dépôt Chorus Pro, e-reporting B2C, extraction IA, validation SIRET INSEE.",
+    },
+  ],
+  publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+};
 
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="fr">
       <head>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
-        <title>InvoiceOps – Facturation électronique IA pour micro-entrepreneurs</title>
-        <meta name="description" content="InvoiceOps automatise la facturation électronique conforme Factur-X, la soumission Chorus Pro et la conformité fiscale pour les micro-entrepreneurs français." />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-
-        {/* Favicon configuration - Override Vercel default */}
-        <link rel="icon" href="/favicon.png" type="image/png" />
-        <link rel="shortcut icon" href="/favicon.png" type="image/png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicon.png" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/favicon.png" />
-
-        {/* PWA Configuration */}
-        <link rel="manifest" href="/manifest.json" />
-        <meta name="theme-color" content="#D4921A" />
-        <meta name="application-name" content="InvoiceOps" />
-        <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-        <meta name="apple-mobile-web-app-title" content="InvoiceOps" />
-        <meta name="msapplication-TileColor" content="#D4921A" />
-
-        <meta name="msapplication-TileImage" content="/icons/icon-144x144.png" />
-        
-        {/* Apple Touch Icons */}
-        <link rel="apple-touch-icon" sizes="72x72" href="/icons/icon-72x72.png" />
-        <link rel="apple-touch-icon" sizes="96x96" href="/icons/icon-96x96.png" />
-        <link rel="apple-touch-icon" sizes="128x128" href="/icons/icon-128x128.png" />
-        <link rel="apple-touch-icon" sizes="144x144" href="/icons/icon-144x144.png" />
-        <link rel="apple-touch-icon" sizes="152x152" href="/icons/icon-152x152.png" />
-        <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192x192.png" />
-        
-        {/* Microsoft Edge/Windows */}
-        <meta name="msapplication-starturl" content="/dashboard" />
-        <meta name="msapplication-navbutton-color" content="#D4921A" />
-        
-        {/* Google Analytics integrated - Force deployment */}
+        <Script id="ld-organization" type="application/ld+json" strategy="beforeInteractive">
+          {JSON.stringify(organizationSchema)}
+        </Script>
+        <Script id="ld-software" type="application/ld+json" strategy="beforeInteractive">
+          {JSON.stringify(softwareSchema)}
+        </Script>
       </head>
       <body className="antialiased" suppressHydrationWarning={true}>
-        <SessionProvider>
-          {isDashboardRoute ? (
-            <ToastProvider>
-              <DashboardNavbar />
-              
-              {/* PWA Components */}
-              <OfflineIndicator showOnlineStatus={true} />
-              <PWAUpdatePrompt />
-              <PWAInstallBadge className="d-lg-none" />
-              
-              <div 
-                className="offcanvas offcanvas-start mobile-sidebar-offcanvas" 
-                tabIndex={-1} 
-                id="mobileSidebar"
-                aria-labelledby="mobileSidebarLabel"
-                style={{ width: '280px' }}
-              >
-                <div className="offcanvas-header border-bottom">
-                  <h5 className="offcanvas-title fw-bold text-primary d-flex align-items-center" id="mobileSidebarLabel">
-                    <i className="bi bi-lightning-fill me-2"></i>
-                    Menu Navigation
-                  </h5>
-                  <button 
-                    type="button" 
-                    className="btn-close mobile-close-btn" 
-                    data-bs-dismiss="offcanvas" 
-                    aria-label="Fermer le menu de navigation"
-                    style={{
-                      minWidth: '32px',
-                      minHeight: '32px',
-                      borderRadius: '8px'
-                    }}
-                  ></button>
-                </div>
-                <div className="offcanvas-body p-0" role="navigation" aria-label="Menu principal">
-                  <Sidebar />
-                </div>
-              </div>
-              {/* Desktop Layout with Fixed Sidebar */}
-              <div className="d-none d-lg-block">
-                <Sidebar />
-                <FixedNotificationCenter />
-                
-                {/* Floating Feedback Button for Desktop */}
-                <div style={{ position: 'fixed', bottom: '20px', right: '20px', zIndex: 1050 }}>
-                  <FeedbackButton 
-                    variant="primary" 
-                    size="md"
-                    className="shadow-lg"
-                    showText={true}
-                  />
-                </div>
-                
-                <main 
-                  style={{ 
-                    marginLeft: '240px',
-                    padding: '2rem',
-                    minHeight: '100vh',
-                    backgroundColor: '#08090a'
-                  }}
-                >
-                  <div className="container-fluid" style={{ maxWidth: '1200px' }}>
-                    {children}
-                  </div>
-                </main>
-              </div>
-              
-              {/* Mobile and Tablet Layout */}
-              <div className="d-lg-none">
-                <FixedNotificationCenter />
-                
-                {/* Floating Close Sidebar Button */}
-                <button
-                  id="floatingCloseSidebar"
-                  className="btn btn-primary shadow-lg d-none"
-                  style={{
-                    position: 'fixed',
-                    top: '50%',
-                    right: '20px',
-                    zIndex: 1040,
-                    width: '48px',
-                    height: '48px',
-                    borderRadius: '50%',
-                    border: 'none',
-                    transform: 'translateY(-50%)',
-                    transition: 'all 0.3s ease-in-out'
-                  }}
-                  onClick={() => {
-                    const offcanvas = document.getElementById('mobileSidebar');
-                    if (offcanvas) {
-                      const bsOffcanvas = (window as any).bootstrap?.Offcanvas?.getInstance(offcanvas);
-                      if (bsOffcanvas) {
-                        bsOffcanvas.hide();
-                      }
-                    }
-                  }}
-                  aria-label="Fermer le menu"
-                >
-                  <i className="bi bi-x" style={{ fontSize: '1.5rem' }}></i>
-                </button>
-
-                {/* Floating Feedback Button for Mobile */}
-                <FeedbackButton variant="floating" />
-                
-                <main 
-                  className="container-fluid px-3 py-3" 
-                  style={{ 
-                    paddingTop: '80px', 
-                    paddingBottom: '20px',
-                    minHeight: '100vh',
-                    backgroundColor: '#0D1117'
-                  }}
-                >
-                  {children}
-                </main>
-              </div>
-            </ToastProvider>
-          ) : (
-            <>
-              <Navbar />
-              <main>{children}</main>
-            </>
-          )}
-          <CookieBanner />
-        </SessionProvider>
-        {analyticsConsent && <GoogleAnalytics gaId="G-VNPY0RYV2B" />}
+        <ClientShell>{children}</ClientShell>
       </body>
     </html>
   );

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://invoiceops.fr";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/api/",
+          "/dashboard/",
+          "/auth/reset-password",
+          "/auth/forgot-password",
+          "/invoices/",
+          "/payment-success",
+          "/offline",
+        ],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,52 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://invoiceops.fr";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    {
+      url: `${SITE_URL}/`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/fonctionnalites`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/comment-ca-marche`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/auth/register`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/auth/signin`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
+    {
+      url: `${SITE_URL}/privacy-policy`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/terms-of-service`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Major SEO upgrade — replaces ad-hoc `<title>`/`<meta>` tags in the client root layout with the full Next.js Metadata API, adds structured data, sitemap, and robots.txt.

### What changes

**Root layout restructured (server component + ClientShell)**
- `app/layout.tsx` is now a server component → unlocks Next's `metadata` and `viewport` exports
- All client-side dashboard logic (sidebar offcanvas, GA, cookie consent, framer-motion, etc.) moved into `app/ClientShell.tsx`
- This was a hard prerequisite — `'use client'` layouts can't export `metadata`

**Full metadata API on home + per-route**
- Title template `%s — InvoiceOps`
- Long-form FR description targeting BTP / Chorus Pro / micro-entrepreneur queries
- 18 keywords spanning Factur-X, autoliquidation, retenue de garantie, factures de situation, EN 16931, e-invoicing, réforme 2026, etc.
- Open Graph (locale fr_FR, image, type=website)
- Twitter card (summary_large_image)
- Canonical URLs and `fr-FR` language alternate
- Per-route `layout.tsx` for `/fonctionnalites`, `/comment-ca-marche`, `/auth/register`, `/auth/signin` with page-specific titles, descriptions, and canonical URLs

**JSON-LD structured data (rich results)**
- `Organization` schema (name, logo, contactPoint, areaServed)
- `SoftwareApplication` schema with Free/Pro offers — eligible for product rich results in Google search
- Injected via `next/script` with `application/ld+json` type

**Sitemap & robots**
- `app/sitemap.ts` → `/sitemap.xml` lists 7 public URLs with priority/changefreq
- `app/robots.ts` → `/robots.txt` disallows `/api`, `/dashboard`, auth flows, payment routes; references sitemap and host

**Manifest cleanup (was a brand bug)**
- `manifest.json` still had old "Splitfact creative agency" content (described as a "creative agency platform", shortcut URLs pointed to `/dashboard/projects`, `/dashboard/analytics`, `/dashboard/collectives` — none of which exist)
- Now correct: InvoiceOps name, BTP/finance description, theme color #D4921A, real shortcut URLs (create-invoice, clients, compliance)

### Why this matters

- Search engines can now crawl proper titles, descriptions, and structured data — previously rendered after JS hydration which Google handles but competitors with SSR metadata outrank in practice
- Social shares (LinkedIn, Twitter, WhatsApp) now show correct title, description, and OG image
- Sitemap submitted to Google Search Console will accelerate indexing of `/fonctionnalites` and `/comment-ca-marche` (the highest-value pages for organic traffic)
- JSON-LD makes the app eligible for rich result cards (free/pro pricing, organization info)

## Test plan
- [ ] `curl https://invoiceops.fr/sitemap.xml` → returns valid XML with 7 URLs
- [ ] `curl https://invoiceops.fr/robots.txt` → has Disallow rules + Sitemap line
- [ ] View source of `/` → contains JSON-LD scripts, OG meta tags, Twitter card
- [ ] LinkedIn URL preview tool: paste invoiceops.fr → renders title, description, image correctly
- [ ] `/fonctionnalites` and `/comment-ca-marche` pages show their own titles in browser tab (not the homepage title)
- [ ] PWA install on mobile: name shows as "InvoiceOps" not "Splitfact"