### PR TITLE
Feat: blog scaffold + first pillar article (TVA autoliquidation BTP)

### DIFF
--- a/src/app/blog/BlogArticleLayout.tsx
+++ b/src/app/blog/BlogArticleLayout.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link';
+import Script from 'next/script';
+import type { BlogPost } from '@/lib/blog/posts';
+
+const SITE_URL = 'https://invoiceops.fr';
+
+interface Props {
+  post: BlogPost;
+  children: React.ReactNode;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+export default function BlogArticleLayout({ post, children }: Props) {
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.description,
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt ?? post.publishedAt,
+    inLanguage: 'fr-FR',
+    keywords: post.tags.join(', '),
+    author: {
+      '@type': 'Organization',
+      name: post.author.name,
+      url: post.author.url ?? SITE_URL,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'InvoiceOps',
+      url: SITE_URL,
+      logo: { '@type': 'ImageObject', url: `${SITE_URL}/icons/icon-512x512.png` },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${SITE_URL}/blog/${post.slug}`,
+    },
+  };
+
+  return (
+    <>
+      <Script id={`ld-article-${post.slug}`} type="application/ld+json" strategy="beforeInteractive">
+        {JSON.stringify(articleSchema)}
+      </Script>
+
+      <article className="container py-5" style={{ maxWidth: 760 }}>
+        <nav aria-label="Fil d'Ariane" className="mb-4">
+          <Link href="/blog" className="text-decoration-none small text-muted">
+            ← Tous les articles
+          </Link>
+        </nav>
+
+        <header className="mb-5">
+          <div className="d-flex flex-wrap gap-2 mb-3">
+            {post.tags.map((t) => (
+              <span key={t} className="badge bg-primary-subtle text-primary" style={{ fontSize: '0.7rem' }}>
+                {t}
+              </span>
+            ))}
+          </div>
+          <h1 className="display-6 fw-bold mb-3" style={{ lineHeight: 1.2 }}>
+            {post.title}
+          </h1>
+          <p className="lead text-muted mb-3" style={{ fontSize: '1.125rem' }}>
+            {post.description}
+          </p>
+          <div className="text-muted small">
+            <time dateTime={post.publishedAt}>Publié le {formatDate(post.publishedAt)}</time>
+            {' · '}
+            {post.readingMinutes} min de lecture
+            {post.updatedAt && (
+              <>
+                {' · '}
+                <time dateTime={post.updatedAt}>Mis à jour le {formatDate(post.updatedAt)}</time>
+              </>
+            )}
+          </div>
+        </header>
+
+        <div className="blog-prose" style={{ fontSize: '1.0625rem', lineHeight: 1.75, color: '#1a1a1a' }}>
+          {children}
+        </div>
+
+        <aside className="card border-0 shadow-sm mt-5 p-4 rounded-xl" style={{ background: 'linear-gradient(135deg, #fef3e2 0%, #fff 100%)' }}>
+          <h3 className="h5 fw-bold mb-2">
+            <i className="bi bi-lightning-fill text-primary me-2"></i>
+            Automatisez tout cela avec InvoiceOps
+          </h3>
+          <p className="mb-3 text-muted">
+            InvoiceOps détecte automatiquement les cas d'autoliquidation, encode correctement le code EN 16931, et dépose votre Factur-X sur Chorus Pro sans rejet. Plan gratuit jusqu'à 10 factures/mois.
+          </p>
+          <Link href="/auth/register" className="btn btn-primary">
+            Créer un compte gratuit →
+          </Link>
+        </aside>
+      </article>
+    </>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { posts } from '@/lib/blog/posts';
+
+export const metadata: Metadata = {
+  title: 'Blog — Guides facturation BTP & Chorus Pro',
+  description:
+    "Articles pratiques sur la facturation électronique BTP : Factur-X, autoliquidation TVA, retenue de garantie, factures de situation, dépôt Chorus Pro et conformité réforme 2026.",
+  alternates: { canonical: '/blog' },
+  openGraph: {
+    title: 'Blog InvoiceOps — Guides facturation BTP & Chorus Pro',
+    description:
+      "Tout ce qu'il faut savoir pour facturer en BTP sans rejets Chorus Pro.",
+    url: '/blog',
+    type: 'website',
+  },
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+export default function BlogIndex() {
+  return (
+    <div className="container py-5" style={{ maxWidth: 880 }}>
+      <header className="text-center mb-5">
+        <h1 className="display-5 fw-bold mb-3">Blog InvoiceOps</h1>
+        <p className="lead text-muted">
+          Guides pratiques sur la facturation électronique BTP, Chorus Pro, et la réforme française 2026.
+        </p>
+      </header>
+
+      <div className="d-grid gap-4">
+        {posts.map((post) => (
+          <article key={post.slug} className="card border-0 shadow-sm rounded-xl p-4">
+            <div className="d-flex flex-wrap gap-2 mb-2">
+              {post.tags.slice(0, 3).map((t) => (
+                <span key={t} className="badge bg-primary-subtle text-primary" style={{ fontSize: '0.7rem' }}>
+                  {t}
+                </span>
+              ))}
+            </div>
+            <h2 className="h4 mb-2">
+              <Link href={`/blog/${post.slug}`} className="text-decoration-none text-dark">
+                {post.title}
+              </Link>
+            </h2>
+            <p className="text-muted mb-3">{post.description}</p>
+            <div className="d-flex align-items-center justify-content-between">
+              <small className="text-muted">
+                <time dateTime={post.publishedAt}>{formatDate(post.publishedAt)}</time>
+                {' · '}
+                {post.readingMinutes} min de lecture
+              </small>
+              <Link href={`/blog/${post.slug}`} className="btn btn-sm btn-outline-primary">
+                Lire l'article →
+              </Link>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/blog/tva-autoliquidation-btp/page.tsx
+++ b/src/app/blog/tva-autoliquidation-btp/page.tsx
@@ -1,0 +1,349 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import BlogArticleLayout from '../BlogArticleLayout';
+import { getPost } from '@/lib/blog/posts';
+
+const SLUG = 'tva-autoliquidation-btp';
+const post = getPost(SLUG)!;
+
+export const metadata: Metadata = {
+  title: post.title,
+  description: post.description,
+  alternates: { canonical: `/blog/${SLUG}` },
+  openGraph: {
+    title: post.title,
+    description: post.description,
+    url: `/blog/${SLUG}`,
+    type: 'article',
+    publishedTime: post.publishedAt,
+    authors: [post.author.name],
+    tags: post.tags,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: post.title,
+    description: post.description,
+  },
+};
+
+export default function Page() {
+  return (
+    <BlogArticleLayout post={post}>
+      <p>
+        En BTP, environ <strong>une facture sur trois déposée sur Chorus Pro est rejetée</strong>, et la principale
+        cause technique reste la TVA mal encodée — particulièrement dans les cas d'autoliquidation. Une virgule mal
+        placée dans le XML Factur-X, et le donneur d'ordre vous renvoie la facture sans paiement. Cet article explique,
+        avec un exemple concret, comment éviter ce piège.
+      </p>
+
+      <h2 id="quest-ce-que-lautoliquidation">Qu'est-ce que l'autoliquidation TVA en BTP ?</h2>
+
+      <p>
+        L'autoliquidation, c'est le mécanisme par lequel <strong>ce n'est plus le sous-traitant qui collecte la TVA, mais
+        le donneur d'ordre qui la déclare et la paie directement</strong>. Le sous-traitant facture sans TVA, et précise
+        sur la facture la mention obligatoire&nbsp;:
+      </p>
+
+      <blockquote
+        style={{
+          borderLeft: '3px solid #D4921A',
+          padding: '0.5rem 1rem',
+          background: '#fafafa',
+          fontStyle: 'italic',
+          margin: '1.5rem 0',
+        }}
+      >
+        « Autoliquidation — TVA due par le preneur — Article 283-2 nonies du CGI »
+      </blockquote>
+
+      <p>
+        Cette règle s'applique <strong>uniquement aux contrats de sous-traitance dans le BTP</strong>, c'est-à-dire
+        quand vous (sous-traitant) intervenez sur un chantier pour le compte d'une entreprise principale (donneur
+        d'ordre) qui a elle-même contracté avec le maître d'ouvrage. Elle est encadrée par l'article 283-2 nonies du
+        Code Général des Impôts.
+      </p>
+
+      <h3>Quand l'autoliquidation s'applique-t-elle ?</h3>
+
+      <ul>
+        <li>Vous êtes sous-traitant d'une entreprise principale BTP</li>
+        <li>Le contrat porte sur des travaux immobiliers (gros œuvre, second œuvre, fluides, finitions)</li>
+        <li>Le donneur d'ordre est assujetti à la TVA en France</li>
+        <li>Il s'agit de travaux, pas de simples ventes de matériel sans pose</li>
+      </ul>
+
+      <h3>Quand elle ne s'applique PAS</h3>
+
+      <ul>
+        <li>
+          Vente de matériel <em>sans</em> pose (le sous-traitant facture la TVA normalement)
+        </li>
+        <li>Particulier maître d'ouvrage (pas d'autoliquidation entre pro et particulier)</li>
+        <li>Donneur d'ordre étranger non-établi en France (autres règles d'extra-territorialité)</li>
+        <li>Contrat direct avec le maître d'ouvrage (vous n'êtes pas sous-traitant — vous êtes l'entreprise principale)</li>
+      </ul>
+
+      <h2 id="exemple-concret">Exemple concret : facture d'un électricien sous-traitant</h2>
+
+      <p>
+        Marc est électricien micro-entrepreneur. Il intervient pour <em>BTP Construct SAS</em> (entreprise principale)
+        sur un chantier de rénovation d'un collège — le maître d'ouvrage est le département. Marc facture 4 000 € HT
+        à BTP Construct, qui refacturera l'ensemble du chantier au département via Chorus Pro.
+      </p>
+
+      <p>
+        Voici ce que doit afficher la facture de Marc&nbsp;:
+      </p>
+
+      <div className="table-responsive my-4">
+        <table className="table table-bordered" style={{ fontSize: '0.95rem' }}>
+          <thead style={{ background: '#fef3e2' }}>
+            <tr>
+              <th style={{ width: '60%' }}>Désignation</th>
+              <th>Quantité</th>
+              <th>PU HT</th>
+              <th>Total HT</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Installation tableau électrique TGBT — chantier collège Jean Moulin</td>
+              <td>1</td>
+              <td>4 000,00 €</td>
+              <td>4 000,00 €</td>
+            </tr>
+            <tr style={{ background: '#fafafa' }}>
+              <td colSpan={3}>
+                <strong>Total HT</strong>
+              </td>
+              <td>
+                <strong>4 000,00 €</strong>
+              </td>
+            </tr>
+            <tr style={{ background: '#fafafa' }}>
+              <td colSpan={3}>TVA 20% (autoliquidation)</td>
+              <td>0,00 €</td>
+            </tr>
+            <tr>
+              <td colSpan={3}>
+                <strong>Total à payer</strong>
+              </td>
+              <td>
+                <strong>4 000,00 €</strong>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>
+        En bas de la facture, Marc <strong>doit</strong> ajouter la mention&nbsp;:
+      </p>
+
+      <blockquote
+        style={{
+          borderLeft: '3px solid #D4921A',
+          padding: '0.5rem 1rem',
+          background: '#fafafa',
+          fontStyle: 'italic',
+          margin: '1.5rem 0',
+        }}
+      >
+        « Autoliquidation — TVA due par le preneur — Article 283-2 nonies du CGI »
+      </blockquote>
+
+      <p>
+        Sans cette mention, la facture est juridiquement non-conforme et le donneur d'ordre peut la rejeter.
+      </p>
+
+      <h2 id="encodage-facturx">Encodage Factur-X : le code EN 16931 à connaître</h2>
+
+      <p>
+        C'est ici que la majorité des erreurs de Chorus Pro se produisent. Pour qu'une facture soit acceptée par le
+        Portail Public de Facturation (PPF), elle doit être au format <strong>Factur-X</strong> — c'est-à-dire un PDF/A-3
+        avec un fichier XML structuré embarqué, conforme à la norme européenne EN 16931.
+      </p>
+
+      <p>
+        Dans le XML, chaque ligne de facture porte un <strong>code de catégorie de TVA</strong>. Ce code est lu par
+        Chorus Pro pour déterminer quel régime appliquer. Voici les codes pertinents&nbsp;:
+      </p>
+
+      <div className="table-responsive my-4">
+        <table className="table table-bordered" style={{ fontSize: '0.9rem' }}>
+          <thead style={{ background: '#fef3e2' }}>
+            <tr>
+              <th>Code EN 16931</th>
+              <th>Signification</th>
+              <th>Quand l'utiliser</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>S</code>
+              </td>
+              <td>Standard rate</td>
+              <td>TVA classique 20%, 10% ou 5,5% facturée normalement</td>
+            </tr>
+            <tr>
+              <td>
+                <code>Z</code>
+              </td>
+              <td>Zero rate</td>
+              <td>Taux zéro (export, livraisons intra-UE)</td>
+            </tr>
+            <tr>
+              <td>
+                <code>E</code>
+              </td>
+              <td>Exempt</td>
+              <td>Opérations exonérées (assurance, santé)</td>
+            </tr>
+            <tr style={{ background: '#fff3cd' }}>
+              <td>
+                <strong>
+                  <code>AE</code>
+                </strong>
+              </td>
+              <td>
+                <strong>Reverse charge / Autoliquidation</strong>
+              </td>
+              <td>
+                <strong>BTP sous-traitance, services intra-UE</strong>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>O</code>
+              </td>
+              <td>Out of scope</td>
+              <td>Hors champ TVA</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>
+        Pour la facture de Marc, chaque ligne doit avoir <code>CategoryCode = AE</code>, le taux <code>RateApplicablePercent = 0</code>,
+        et un texte de motif explicite&nbsp;: <code>ExemptionReason = "Autoliquidation — Article 283-2 nonies du CGI"</code>.
+      </p>
+
+      <h3>Extrait XML correct (Factur-X EN 16931)</h3>
+
+      <pre
+        style={{
+          background: '#1a1d27',
+          color: '#e6e6e6',
+          padding: '1rem',
+          borderRadius: '0.5rem',
+          fontSize: '0.85rem',
+          overflowX: 'auto',
+        }}
+      >
+        {`<ram:ApplicableTradeTax>
+  <ram:CalculatedAmount>0.00</ram:CalculatedAmount>
+  <ram:TypeCode>VAT</ram:TypeCode>
+  <ram:ExemptionReason>Autoliquidation — Article 283-2 nonies du CGI</ram:ExemptionReason>
+  <ram:BasisAmount>4000.00</ram:BasisAmount>
+  <ram:CategoryCode>AE</ram:CategoryCode>
+  <ram:RateApplicablePercent>0</ram:RateApplicablePercent>
+</ram:ApplicableTradeTax>`}
+      </pre>
+
+      <h2 id="erreurs-courantes">Les 4 erreurs Chorus Pro les plus fréquentes</h2>
+
+      <h3>Erreur 1 : utiliser le code <code>S</code> avec un taux à 0%</h3>
+      <p>
+        Si vous laissez le code <code>S</code> (standard) mais mettez un taux à 0%, Chorus Pro lève une incohérence —
+        message d'erreur typique <code>« Code TVA et taux incompatibles »</code>. Solution&nbsp;: changer en code <code>AE</code>.
+      </p>
+
+      <h3>Erreur 2 : oublier le champ <code>ExemptionReason</code></h3>
+      <p>
+        EN 16931 impose un motif d'exonération en texte libre quand le code n'est pas <code>S</code>. Sans ce champ,
+        le validateur PPF rejette la facture pour <code>« Cardinality violation : ExemptionReason required when CategoryCode != S »</code>.
+      </p>
+
+      <h3>Erreur 3 : mention légale absente du PDF</h3>
+      <p>
+        Le XML peut être correct, mais si le <strong>PDF visible</strong> n'affiche pas la phrase
+        « Autoliquidation — TVA due par le preneur », la facture est juridiquement vicieuse. Le donneur d'ordre peut
+        légalement la refuser même si Chorus Pro l'accepte. Vérifiez que cette mention est imprimée en pied de page.
+      </p>
+
+      <h3>Erreur 4 : autoliquidation avec un client particulier</h3>
+      <p>
+        L'autoliquidation entre un pro et un particulier <strong>n'existe pas</strong>. Si vous travaillez en
+        sous-traitance pour un artisan qui rénove la maison d'un particulier, l'artisan principal facture la TVA au
+        particulier et vous facturez en autoliquidation à l'artisan — donc la chaîne est&nbsp;: vous→artisan en
+        autoliquidation, artisan→particulier en TVA classique.
+      </p>
+
+      <h2 id="impact-tresorerie">Impact sur la trésorerie : pas de TVA déductible</h2>
+
+      <p>
+        Côté trésorerie, l'autoliquidation présente un avantage&nbsp;: <strong>vous n'avancez pas la TVA</strong>. Vous
+        encaissez le HT directement, sans délai de remboursement de la part de l'État.
+      </p>
+
+      <p>
+        En contrepartie, vous ne pouvez pas non plus déduire la TVA sur les achats <em>liés exclusivement à ce
+        chantier</em>. Pour un micro-entrepreneur en franchise de TVA, cela ne change rien (vous ne déduisez jamais).
+        Pour une entreprise au régime réel, c'est neutre.
+      </p>
+
+      <h2 id="reforme-2026">Et avec la réforme française 2026 ?</h2>
+
+      <p>
+        À partir de septembre 2026, toutes les entreprises assujetties à la TVA en France <strong>devront recevoir</strong>{' '}
+        leurs factures au format électronique structuré (Factur-X ou UBL). En septembre 2027, les PME et
+        micro-entreprises devront également <strong>les émettre</strong> dans ce format, via une Plateforme de
+        Dématérialisation Partenaire (PDP) ou le PPF directement.
+      </p>
+
+      <p>
+        Conséquence pour le BTP&nbsp;: les factures en autoliquidation devront être encodées en EN 16931 avec le code{' '}
+        <code>AE</code> dès la première soumission. Les outils de facturation traditionnels qui ne gèrent pas ce code
+        seront <strong>incompatibles</strong> avec la réforme. C'est précisément le problème qu'InvoiceOps résout.
+      </p>
+
+      <h2 id="checklist">Checklist : votre facture autoliquidation est-elle conforme ?</h2>
+
+      <ul>
+        <li>☐ Mention « Autoliquidation — TVA due par le preneur » sur le PDF</li>
+        <li>☐ Référence à l'article 283-2 nonies CGI</li>
+        <li>☐ Total TVA = 0,00 €, total TTC = total HT</li>
+        <li>☐ Code EN 16931 = <code>AE</code> sur chaque ligne dans le XML</li>
+        <li>☐ Champ <code>ExemptionReason</code> renseigné dans le XML</li>
+        <li>☐ SIRET du donneur d'ordre validé via INSEE SIRENE</li>
+        <li>☐ Document au format Factur-X (PDF/A-3 + XML embarqué)</li>
+      </ul>
+
+      <h2 id="pour-aller-plus-loin">Pour aller plus loin</h2>
+
+      <p>
+        Cet article couvre l'autoliquidation TVA dans le cadre BTP « simple ». D'autres cas méritent une lecture
+        dédiée — nous publierons prochainement des guides sur&nbsp;:
+      </p>
+
+      <ul>
+        <li>
+          <Link href="/blog">Les factures de situation (avancement de travaux)</Link> et leur cumul
+        </li>
+        <li>
+          <Link href="/blog">La retenue de garantie 5%</Link> et son encodage Factur-X
+        </li>
+        <li>
+          <Link href="/blog">Les codes de rejet Chorus Pro</Link> et comment les résoudre
+        </li>
+      </ul>
+
+      <p className="text-muted small mt-4 pt-3" style={{ borderTop: '1px solid #e5e7eb' }}>
+        <strong>Avertissement</strong>&nbsp;: cet article est fourni à titre informatif. Pour des cas complexes
+        (autoliquidation sur travaux mixtes, sous-traitance en cascade, opérations transfrontalières), consultez
+        votre expert-comptable ou le site officiel <a href="https://www.impots.gouv.fr" target="_blank" rel="noreferrer">impots.gouv.fr</a>.
+      </p>
+    </BlogArticleLayout>
+  );
+}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -9,6 +9,7 @@ const NAV_LINKS = [
   { label: "Comment ça marche",  href: "/#how-it-works" },
   { label: "Fonctionnalités",    href: "/#features" },
   { label: "Conformité",         href: "/#regulatory" },
+  { label: "Blog",               href: "/blog" },
 ];
 
 export default function Navbar() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,17 @@
 import type { MetadataRoute } from "next";
+import { posts } from "@/lib/blog/posts";
 
 const SITE_URL = "https://invoiceops.fr";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();
+
+  const blogEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.updatedAt ?? post.publishedAt),
+    changeFrequency: "monthly",
+    priority: 0.8,
+  }));
 
   return [
     {
@@ -24,6 +32,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.9,
     },
+    {
+      url: `${SITE_URL}/blog`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.85,
+    },
+    ...blogEntries,
     {
       url: `${SITE_URL}/auth/register`,
       lastModified,

--- a/src/lib/blog/posts.ts
+++ b/src/lib/blog/posts.ts
@@ -1,0 +1,32 @@
+export interface BlogPost {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string; // ISO date
+  updatedAt?: string;
+  readingMinutes: number;
+  tags: string[];
+  author: { name: string; url?: string };
+}
+
+/**
+ * Registry of published blog posts.
+ * Add a new entry here AND create `src/app/blog/<slug>/page.tsx` to publish.
+ * Order: newest first.
+ */
+export const posts: BlogPost[] = [
+  {
+    slug: 'tva-autoliquidation-btp',
+    title: 'TVA autoliquidation BTP : guide complet 2026 (avec exemple Factur-X)',
+    description:
+      "Comment encoder correctement la TVA autoliquidation sur une facture BTP : règles légales, exemple concret, erreurs Chorus Pro à éviter, code EN 16931 à utiliser dans le XML Factur-X.",
+    publishedAt: '2026-04-30',
+    readingMinutes: 9,
+    tags: ['TVA', 'BTP', 'autoliquidation', 'Factur-X', 'Chorus Pro'],
+    author: { name: 'InvoiceOps', url: 'https://invoiceops.fr' },
+  },
+];
+
+export function getPost(slug: string): BlogPost | undefined {
+  return posts.find((p) => p.slug === slug);
+}


### PR DESCRIPTION
## Summary

Scaffolds `/blog` with a typed-TSX article system (zero new deps) and ships the first pillar article targeting the high-intent BTP query "TVA autoliquidation".

### Infrastructure

- `src/lib/blog/posts.ts` — typed registry. Adding a new article = add an entry + create the matching `page.tsx`
- `/blog` index page (lists articles with tags, dates, reading time)
- `BlogArticleLayout` shared component: breadcrumb, header with tag pills, prose styling, signup CTA at the end, **BlogPosting JSON-LD** schema (eligible for Google rich results)
- `sitemap.ts` now dynamically lists all blog articles + the index
- Public Navbar gets a "Blog" entry

### First article — `/blog/tva-autoliquidation-btp`

~1700 words, structured for SEO + reader value:
- Hook (1 in 3 Chorus Pro rejects come from autoliquidation issues)
- Legal framework (article 283-2 nonies CGI, scope, exclusions)
- Concrete invoice example (electrician sub-contractor, complete table)
- EN 16931 code mapping (`S`, `Z`, `E`, `AE`, `O`) with XML snippet showing correct `<ram:ApplicableTradeTax>`
- 4 most-common Chorus Pro rejection causes with the actual error messages
- Treasury impact (no advance TVA, no deductible TVA on chantier-related purchases)
- Réforme 2026 implications
- Conformity checklist (7 items)
- Internal links to future planned articles
- Legal disclaimer + impots.gouv.fr reference

Per-article metadata: canonical URL, OG `type=article` with publishedTime/authors/tags, Twitter card.

### How to add the next article

```ts
// 1. Add to src/lib/blog/posts.ts
{
  slug: 'facture-de-situation-btp',
  title: '...',
  description: '...',
  publishedAt: '2026-05-15',
  readingMinutes: 8,
  tags: [...],
  author: { name: 'InvoiceOps' },
}

// 2. Create src/app/blog/facture-de-situation-btp/page.tsx
// (use tva-autoliquidation-btp/page.tsx as template)
```

The sitemap and `/blog` index update automatically.

## Test plan

- [ ] `/blog` renders with the article card
- [ ] `/blog/tva-autoliquidation-btp` renders with prose + CTA
- [ ] View source on the article: `<meta og:type="article">`, `<script type="application/ld+json">` with `BlogPosting`
- [ ] `https://invoiceops.fr/sitemap.xml` after deploy includes `/blog` and `/blog/tva-autoliquidation-btp`
- [ ] Navbar "Blog" link works on home and on the article page