### PR TITLE
fix(blog): make TVA autoliquidation article readable on dark theme

### DIFF
--- a/src/app/blog/BlogArticleLayout.tsx
+++ b/src/app/blog/BlogArticleLayout.tsx
@@ -80,7 +80,10 @@ export default function BlogArticleLayout({ post, children }: Props) {
           </div>
         </header>
 
-        <div className="blog-prose" style={{ fontSize: '1.0625rem', lineHeight: 1.75, color: '#1a1a1a' }}>
+        <div
+          className="blog-prose"
+          style={{ fontSize: '1.0625rem', lineHeight: 1.75, color: 'var(--text-secondary)' }}
+        >
           {children}
         </div>
 

--- a/src/app/blog/tva-autoliquidation-btp/page.tsx
+++ b/src/app/blog/tva-autoliquidation-btp/page.tsx
@@ -46,11 +46,13 @@ export default function Page() {
 
       <blockquote
         style={{
-          borderLeft: '3px solid #D4921A',
-          padding: '0.5rem 1rem',
-          background: '#fafafa',
+          borderLeft: '3px solid var(--gold)',
+          padding: '0.75rem 1rem',
+          background: 'var(--gold-surface)',
+          color: 'var(--text-primary)',
           fontStyle: 'italic',
           margin: '1.5rem 0',
+          borderRadius: '0 var(--radius-md) var(--radius-md) 0',
         }}
       >
         « Autoliquidation — TVA due par le preneur — Article 283-2 nonies du CGI »
@@ -97,7 +99,7 @@ export default function Page() {
 
       <div className="table-responsive my-4">
         <table className="table table-bordered" style={{ fontSize: '0.95rem' }}>
-          <thead style={{ background: '#fef3e2' }}>
+          <thead style={{ background: 'var(--gold-surface)' }}>
             <tr>
               <th style={{ width: '60%' }}>Désignation</th>
               <th>Quantité</th>
@@ -112,7 +114,7 @@ export default function Page() {
               <td>4 000,00 €</td>
               <td>4 000,00 €</td>
             </tr>
-            <tr style={{ background: '#fafafa' }}>
+            <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
               <td colSpan={3}>
                 <strong>Total HT</strong>
               </td>
@@ -120,7 +122,7 @@ export default function Page() {
                 <strong>4 000,00 €</strong>
               </td>
             </tr>
-            <tr style={{ background: '#fafafa' }}>
+            <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
               <td colSpan={3}>TVA 20% (autoliquidation)</td>
               <td>0,00 €</td>
             </tr>
@@ -142,11 +144,13 @@ export default function Page() {
 
       <blockquote
         style={{
-          borderLeft: '3px solid #D4921A',
-          padding: '0.5rem 1rem',
-          background: '#fafafa',
+          borderLeft: '3px solid var(--gold)',
+          padding: '0.75rem 1rem',
+          background: 'var(--gold-surface)',
+          color: 'var(--text-primary)',
           fontStyle: 'italic',
           margin: '1.5rem 0',
+          borderRadius: '0 var(--radius-md) var(--radius-md) 0',
         }}
       >
         « Autoliquidation — TVA due par le preneur — Article 283-2 nonies du CGI »
@@ -171,7 +175,7 @@ export default function Page() {
 
       <div className="table-responsive my-4">
         <table className="table table-bordered" style={{ fontSize: '0.9rem' }}>
-          <thead style={{ background: '#fef3e2' }}>
+          <thead style={{ background: 'var(--gold-surface)' }}>
             <tr>
               <th>Code EN 16931</th>
               <th>Signification</th>
@@ -200,7 +204,7 @@ export default function Page() {
               <td>Exempt</td>
               <td>Opérations exonérées (assurance, santé)</td>
             </tr>
-            <tr style={{ background: '#fff3cd' }}>
+            <tr style={{ background: 'var(--gold-surface)' }}>
               <td>
                 <strong>
                   <code>AE</code>


### PR DESCRIPTION
## Summary
- Blog article `/blog/tva-autoliquidation-btp` set body text to `#1a1a1a` (near-black) on the site's near-black canvas, so paragraphs/lists were invisible until the user selected them — reported as a bad UX on production.
- Switched `.blog-prose` color to `var(--text-secondary)` and re-themed the cream blockquote/table backgrounds (`#fafafa`, `#fef3e2`, `#fff3cd`) to dark-theme tokens (`var(--gold-surface)`, subtle white-on-dark) so contrast holds.

## Test plan
- [ ] `npm run dev` and load `/blog/tva-autoliquidation-btp` — body copy, both « Autoliquidation… » blockquotes, and the EN 16931 code-table rows are readable without selection
- [ ] Inline code (`AE`, `S`, etc.) still renders gold on dark
- [ ] Dark `<pre>` XML block still readable