### PR TITLE
Release: /pricing + retenue-de-garantie blog

### DIFF
--- a/src/app/blog/retenue-de-garantie-btp-facturx/page.tsx
+++ b/src/app/blog/retenue-de-garantie-btp-facturx/page.tsx
@@ -1,0 +1,388 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import BlogArticleLayout from '../BlogArticleLayout';
+import { getPost } from '@/lib/blog/posts';
+
+const SLUG = 'retenue-de-garantie-btp-facturx';
+const post = getPost(SLUG)!;
+
+export const metadata: Metadata = {
+  title: post.title,
+  description: post.description,
+  alternates: { canonical: `/blog/${SLUG}` },
+  openGraph: {
+    title: post.title,
+    description: post.description,
+    url: `/blog/${SLUG}`,
+    type: 'article',
+    publishedTime: post.publishedAt,
+    authors: [post.author.name],
+    tags: post.tags,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: post.title,
+    description: post.description,
+  },
+};
+
+export default function Page() {
+  return (
+    <BlogArticleLayout post={post}>
+      <p>
+        La retenue de garantie de 5% est l'un des trois pièges qui font rejeter le plus de factures BTP sur Chorus Pro,
+        avec l'autoliquidation TVA et les factures de situation. Mal présentée sur le PDF ou mal encodée dans le XML
+        Factur-X, elle bloque le paiement et oblige à recommencer la procédure. Cet article explique comment la
+        formaliser correctement, avec un exemple chiffré et l'extrait XML conforme.
+      </p>
+
+      <h2 id="quest-ce-que-la-rg">Qu'est-ce que la retenue de garantie 5% ?</h2>
+
+      <p>
+        La <strong>retenue de garantie</strong> (RG) est une fraction du montant facturé que le maître d'ouvrage (ou le
+        donneur d'ordre) conserve pendant <strong>une année après la réception des travaux</strong>, à titre de
+        garantie contre d'éventuelles malfaçons. Son taux légal maximum est de <strong>5%</strong> du montant TTC du
+        marché, et elle est encadrée par&nbsp;:
+      </p>
+
+      <ul>
+        <li>L'article <strong>1799-1 du Code de la construction et de l'habitation</strong> pour les marchés privés</li>
+        <li>Les articles <strong>R. 2191-32 à R. 2191-37 du Code de la commande publique</strong> pour les marchés publics</li>
+        <li>L'article <strong>L. 111-5 du Code de la consommation</strong> pour les contrats avec un particulier</li>
+      </ul>
+
+      <h3>Quand la RG s'applique-t-elle ?</h3>
+
+      <ul>
+        <li>Marchés <strong>publics</strong> de travaux passés par l'État, une collectivité, un hôpital, etc.</li>
+        <li>Marchés <strong>privés</strong> dès que le contrat le prévoit (clause CCAG, CCAP, ou marché type FFB)</li>
+        <li>Sous-traitance BTP : la RG est répercutée par le donneur d'ordre sur le sous-traitant</li>
+      </ul>
+
+      <h3>Quand elle ne s'applique PAS</h3>
+
+      <ul>
+        <li>Le contrat ne la prévoit pas explicitement (sauf marchés publics où elle est de droit)</li>
+        <li>L'entrepreneur a fourni une <strong>caution bancaire</strong> à première demande à la place — la RG est alors libérée immédiatement</li>
+        <li>Vente de matériel sans pose</li>
+      </ul>
+
+      <h2 id="exemple-chiffre">Exemple chiffré : facture d'un maçon sous-traitant</h2>
+
+      <p>
+        Sylvie est maçon, sous-traitante d'<em>BTP Construct SAS</em> sur un chantier de rénovation d'école. Son marché
+        prévoit une RG de 5% sur le TTC. Comme c'est de la sous-traitance BTP, elle facture également en autoliquidation
+        TVA. Voici ce que doit afficher sa facture pour 8 000 € HT de travaux&nbsp;:
+      </p>
+
+      <div className="table-responsive my-4">
+        <table className="table table-bordered" style={{ fontSize: '0.95rem' }}>
+          <thead style={{ background: 'var(--gold-surface)' }}>
+            <tr>
+              <th style={{ width: '60%' }}>Désignation</th>
+              <th>Quantité</th>
+              <th>PU HT</th>
+              <th>Total HT</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Reprise de murs porteurs — chantier école Pasteur</td>
+              <td>1</td>
+              <td>8 000,00 €</td>
+              <td>8 000,00 €</td>
+            </tr>
+            <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
+              <td colSpan={3}>
+                <strong>Total HT</strong>
+              </td>
+              <td>
+                <strong>8 000,00 €</strong>
+              </td>
+            </tr>
+            <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
+              <td colSpan={3}>TVA 20% (autoliquidation — code AE)</td>
+              <td>0,00 €</td>
+            </tr>
+            <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
+              <td colSpan={3}>
+                <strong>Total TTC</strong>
+              </td>
+              <td>
+                <strong>8 000,00 €</strong>
+              </td>
+            </tr>
+            <tr style={{ background: 'rgba(255,180,0,0.08)' }}>
+              <td colSpan={3}>
+                <strong>Retenue de garantie 5%</strong> (libération sous 1 an)
+              </td>
+              <td>
+                <strong>− 400,00 €</strong>
+              </td>
+            </tr>
+            <tr>
+              <td colSpan={3}>
+                <strong>Net à payer</strong>
+              </td>
+              <td>
+                <strong>7 600,00 €</strong>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>
+        En pied de facture, Sylvie <strong>doit</strong> ajouter la mention&nbsp;:
+      </p>
+
+      <blockquote
+        style={{
+          borderLeft: '3px solid var(--gold)',
+          padding: '0.75rem 1rem',
+          background: 'var(--gold-surface)',
+          color: 'var(--text-primary)',
+          fontStyle: 'italic',
+          margin: '1.5rem 0',
+          borderRadius: '0 var(--radius-md) var(--radius-md) 0',
+        }}
+      >
+        « Retenue de garantie 5% conformément à l'article 1799-1 du CCH — libération à l'issue du délai de garantie d'un an
+        à compter de la réception des travaux. »
+      </blockquote>
+
+      <p>
+        Sans cette mention <strong>et</strong> sans la ligne explicite « Retenue de garantie » dans le détail des
+        montants, le donneur d'ordre est en droit de payer le TTC complet — ce qui semble bénéfique mais provoque, en
+        pratique, une re-facturation après réception. C'est le moment où Chorus Pro se complique.
+      </p>
+
+      <h2 id="encodage-facturx">Encodage Factur-X : le code EN 16931 à utiliser</h2>
+
+      <p>
+        Dans le XML Factur-X, la retenue de garantie n'est <strong>pas</strong> une remise commerciale ni une déduction
+        de TVA. C'est une <strong>retenue sur paiement</strong> qui doit apparaître au niveau du document, pas de la
+        ligne. La norme EN 16931 prévoit pour cela un élément{' '}
+        <code>SpecifiedTradeAllowanceCharge</code> avec un code de raison spécifique.
+      </p>
+
+      <p>
+        Le code à utiliser est <strong>BT-92 / Code 102</strong> (UNTDID 5189 — « Retention »), avec un{' '}
+        <code>ChargeIndicator</code> à <code>false</code> (c'est une déduction).
+      </p>
+
+      <div className="table-responsive my-4">
+        <table className="table table-bordered" style={{ fontSize: '0.9rem' }}>
+          <thead style={{ background: 'var(--gold-surface)' }}>
+            <tr>
+              <th>Champ EN 16931</th>
+              <th>Valeur pour la RG</th>
+              <th>Commentaire</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>ChargeIndicator</code>
+              </td>
+              <td>
+                <code>false</code>
+              </td>
+              <td>C'est une déduction, pas un frais ajouté</td>
+            </tr>
+            <tr>
+              <td>
+                <code>ActualAmount</code>
+              </td>
+              <td>
+                <code>400.00</code>
+              </td>
+              <td>Montant absolu en euros</td>
+            </tr>
+            <tr style={{ background: 'var(--gold-surface)' }}>
+              <td>
+                <strong>
+                  <code>ReasonCode</code>
+                </strong>
+              </td>
+              <td>
+                <strong>
+                  <code>102</code>
+                </strong>
+              </td>
+              <td>
+                <strong>« Retention » — UNTDID 5189</strong>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>Reason</code>
+              </td>
+              <td>
+                <code>"Retenue de garantie 5%"</code>
+              </td>
+              <td>Texte libre lisible par l'humain</td>
+            </tr>
+            <tr>
+              <td>
+                <code>CategoryTradeTax</code>
+              </td>
+              <td>
+                <code>AE</code>
+              </td>
+              <td>Doit reprendre le code TVA de la facture (autoliquidation ici)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Extrait XML correct (Factur-X EN 16931)</h3>
+
+      <pre
+        style={{
+          background: '#1a1d27',
+          color: '#e6e6e6',
+          padding: '1rem',
+          borderRadius: '0.5rem',
+          fontSize: '0.85rem',
+          overflowX: 'auto',
+        }}
+      >
+        {`<ram:SpecifiedTradeAllowanceCharge>
+  <ram:ChargeIndicator>
+    <udt:Indicator>false</udt:Indicator>
+  </ram:ChargeIndicator>
+  <ram:ActualAmount>400.00</ram:ActualAmount>
+  <ram:ReasonCode>102</ram:ReasonCode>
+  <ram:Reason>Retenue de garantie 5%</ram:Reason>
+  <ram:CategoryTradeTax>
+    <ram:TypeCode>VAT</ram:TypeCode>
+    <ram:CategoryCode>AE</ram:CategoryCode>
+    <ram:RateApplicablePercent>0</ram:RateApplicablePercent>
+  </ram:CategoryTradeTax>
+</ram:SpecifiedTradeAllowanceCharge>`}
+      </pre>
+
+      <p>
+        Le bloc s'insère <strong>au niveau du document</strong> (dans <code>ApplicableHeaderTradeSettlement</code>),
+        après les lignes de facture mais avant le bloc <code>SpecifiedTradeSettlementHeaderMonetarySummation</code>. Le
+        montant net à payer doit refléter la RG&nbsp;:{' '}
+        <code>DuePayableAmount = TotalTTC − Retenue = 8000 − 400 = 7600</code>.
+      </p>
+
+      <h2 id="erreurs-courantes">Les 4 erreurs Chorus Pro les plus fréquentes</h2>
+
+      <h3>Erreur 1 : encoder la RG comme une remise commerciale</h3>
+      <p>
+        Beaucoup d'outils de facturation traitent la RG comme une <code>ReasonCode = 95</code> (« Discount »). Chorus
+        Pro accepte le XML mais le donneur d'ordre comptabilise une <em>remise définitive</em> au lieu d'une retenue
+        temporaire — la RG ne sera jamais libérée. Solution&nbsp;: utiliser <code>ReasonCode = 102</code> (Retention).
+      </p>
+
+      <h3>Erreur 2 : déduire la RG du montant HT au lieu du TTC</h3>
+      <p>
+        La RG s'applique sur le <strong>TTC</strong> (article 1799-1 CCH), même si dans une facture en autoliquidation
+        le TTC = HT. Pour une facture standard avec TVA collectée, déduire la RG du HT sous-évalue la retenue de 20%.
+        Le donneur d'ordre détecte l'écart et rejette ou paie un montant erroné.
+      </p>
+
+      <h3>Erreur 3 : oublier le <code>CategoryTradeTax</code> sur le bloc RG</h3>
+      <p>
+        EN 16931 impose qu'une déduction au niveau document reprenne le régime TVA appliqué. Sans ce sous-élément,
+        Chorus Pro lève l'erreur{' '}
+        <code>« Cardinality violation : CategoryTradeTax required on TradeAllowanceCharge »</code>.
+      </p>
+
+      <h3>Erreur 4 : facturer la libération de RG sans nouveau Factur-X</h3>
+      <p>
+        À l'issue du délai d'un an, la libération de la RG <strong>n'est pas un avoir</strong> sur la facture d'origine
+        — c'est une <strong>nouvelle facture</strong> portant uniquement la mention « Libération de la retenue de
+        garantie — facture n°XXXX du JJ/MM/AAAA », au format Factur-X complet. Sans nouveau dépôt PPF, le donneur
+        d'ordre ne peut pas mandater le paiement.
+      </p>
+
+      <h2 id="caution-alternative">L'alternative : la caution bancaire à première demande</h2>
+
+      <p>
+        Si vous voulez encaisser 100% du marché immédiatement, vous pouvez fournir une <strong>caution bancaire à
+        première demande</strong> d'un montant équivalent à 5% du marché (article 1799-1 CCH). Le donneur d'ordre
+        renonce alors à la retenue. Coût bancaire&nbsp;: typiquement <strong>0,5% à 1,5% par an</strong> du montant
+        cautionné, soit pour un marché de 100 000 € une caution de 5 000 € à environ 50 €/an.
+      </p>
+
+      <p>
+        En pratique, la caution est intéressante si&nbsp;:
+      </p>
+
+      <ul>
+        <li>Vous avez besoin de la trésorerie maintenant (cas d'achats matériel à honorer)</li>
+        <li>Le coût bancaire est inférieur au coût d'opportunité de la trésorerie immobilisée</li>
+        <li>Votre banque vous l'accorde rapidement (encours, garanties)</li>
+      </ul>
+
+      <h2 id="liberation">Comment se passe la libération de la RG ?</h2>
+
+      <p>
+        Au terme du délai de garantie d'un an à compter de la réception des travaux (ou réception définitive selon le
+        marché), <strong>vous devez émettre une facture distincte</strong> pour réclamer la RG. Cette facture porte&nbsp;:
+      </p>
+
+      <ul>
+        <li>Référence à la facture initiale&nbsp;: <code>« Libération de la RG — facture n°2026-042 du 15/05/2026 »</code></li>
+        <li>Le montant exact de la RG retenue (400 € dans notre exemple)</li>
+        <li>Le même régime TVA (autoliquidation si la facture initiale l'était)</li>
+        <li>Le même format Factur-X et un dépôt Chorus Pro distinct</li>
+      </ul>
+
+      <p>
+        Si le donneur d'ordre tarde à libérer la RG, l'article 1799-1 du CCH prévoit qu'à défaut de notification de
+        malfaçon dans les 30 jours suivant la fin du délai de garantie, la RG est <strong>réputée acquise</strong> de
+        plein droit.
+      </p>
+
+      <h2 id="reforme-2026">Et avec la réforme française 2026 ?</h2>
+
+      <p>
+        La réforme e-invoicing 2026-2027 ne change pas les règles de la RG, mais elle <strong>renforce l'exigence
+        d'encodage XML</strong>. À partir de septembre 2027, toutes les factures BTP devront passer par une PDP ou le
+        PPF directement, et chaque déduction document devra être structurée en EN 16931. Les outils qui se contentent
+        d'écrire « − 5% RG » dans une cellule de tableau PDF seront <strong>incompatibles</strong> avec la réforme.
+      </p>
+
+      <h2 id="checklist">Checklist : votre facture avec retenue est-elle conforme ?</h2>
+
+      <ul>
+        <li>☐ Mention « Retenue de garantie 5% — article 1799-1 CCH » sur le PDF</li>
+        <li>☐ Ligne « Retenue de garantie » distincte dans le détail des montants</li>
+        <li>☐ Calcul sur le TTC, pas sur le HT</li>
+        <li>☐ Net à payer = TTC − RG (champ <code>DuePayableAmount</code>)</li>
+        <li>☐ Bloc <code>SpecifiedTradeAllowanceCharge</code> au niveau document dans le XML</li>
+        <li>☐ <code>ReasonCode = 102</code> (et non 95 « Discount »)</li>
+        <li>☐ <code>CategoryTradeTax</code> reprend le régime TVA (souvent <code>AE</code> en sous-traitance BTP)</li>
+        <li>☐ Document au format Factur-X (PDF/A-3 + XML embarqué)</li>
+        <li>☐ Plan de libération communiqué (date prévisionnelle)</li>
+      </ul>
+
+      <h2 id="pour-aller-plus-loin">Pour aller plus loin</h2>
+
+      <p>
+        La retenue de garantie est rarement seule sur une facture BTP. Elle se combine systématiquement avec d'autres
+        mécanismes&nbsp;:
+      </p>
+
+      <ul>
+        <li>
+          <Link href="/blog/tva-autoliquidation-btp">L'autoliquidation TVA</Link> en sous-traitance (le code <code>AE</code> et la mention 283-2 nonies CGI)
+        </li>
+        <li>Les factures de situation sur travaux longs (cumul, références au marché — article à venir)</li>
+        <li>Le décompte général et définitif (DGD) à la réception</li>
+      </ul>
+
+      <p>
+        InvoiceOps gère ces trois cas nativement&nbsp;: la RG est calculée automatiquement sur le TTC, l'XML Factur-X
+        est encodé avec le bon <code>ReasonCode = 102</code>, et le suivi de libération de RG est géré dans votre
+        tableau de bord. Plan gratuit jusqu'à 10 factures/mois pour tester sur vos chantiers en cours.
+      </p>
+    </BlogArticleLayout>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1465,7 +1465,7 @@ export default function LandingPage() {
                 links: [
                   { label: "Comment ça marche", href: "#how-it-works" },
                   { label: "Fonctionnalités", href: "#benefits" },
-                  { label: "Tarifs", href: "#pricing" },
+                  { label: "Tarifs", href: "/pricing" },
                   { label: "Programme pilote", href: "#design-partner-form" },
                 ],
               },

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,407 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'Tarifs InvoiceOps — Plan gratuit + Pro 49€/mois (30 jours offerts)',
+  description:
+    "Plan gratuit (10 factures/mois) + Plan Pro (49€/mois) avec dépôt Chorus Pro illimité, Factur-X conforme EN 16931, e-reporting B2C et 30 jours d'essai gratuit. Pas de carte bancaire requise.",
+  alternates: { canonical: '/pricing' },
+  openGraph: {
+    title: 'Tarifs InvoiceOps — Gratuit ou Pro 49€/mois',
+    description:
+      "Le plan Pro inclut Factur-X, dépôt Chorus Pro/PPF, e-reporting DGFiP et validation SIRET. 30 jours offerts, sans carte bancaire.",
+    url: '/pricing',
+    type: 'website',
+  },
+};
+
+const freeFeatures = [
+  "Jusqu'à 10 factures / mois",
+  "Création manuelle",
+  "Clients illimités",
+  "Tableau de bord basique",
+  "Lien de paiement Stripe",
+];
+
+const proFeatures = [
+  "Factures illimitées",
+  "Extraction IA (OCR image & PDF)",
+  "Génération Factur-X (PDF/A-3 + XML)",
+  "Dépôt Chorus Pro / PPF direct",
+  "E-reporting B2C (art. 290 CGI)",
+  "Score de conformité EN 16931",
+  "Inbox des exceptions centralisée",
+  "Facturation récurrente automatique",
+  "Polling statut PPF en temps réel",
+  "Validation SIRET (INSEE SIRENE)",
+  "Journal d'audit complet",
+  "Notifications avec file de retry",
+];
+
+const comparison: { feature: string; free: string | boolean; pro: string | boolean }[] = [
+  { feature: "Volume mensuel de factures", free: "10", pro: "Illimité" },
+  { feature: "Génération Factur-X (PDF/A-3 + XML)", free: false, pro: true },
+  { feature: "Dépôt direct Chorus Pro / PPF", free: false, pro: true },
+  { feature: "Extraction IA (OCR image & PDF)", free: false, pro: true },
+  { feature: "Validation SIRET (INSEE SIRENE)", free: false, pro: true },
+  { feature: "E-reporting B2C automatique", free: false, pro: true },
+  { feature: "Score de conformité EN 16931", free: false, pro: true },
+  { feature: "Polling statut PPF temps réel", free: false, pro: true },
+  { feature: "Facturation récurrente", free: false, pro: true },
+  { feature: "Inbox des exceptions", free: false, pro: true },
+  { feature: "Journal d'audit complet", free: false, pro: true },
+  { feature: "Lien de paiement Stripe", free: true, pro: true },
+  { feature: "Tableau de bord", free: "Basique", pro: "Complet" },
+  { feature: "Support", free: "Email", pro: "Email prioritaire" },
+];
+
+const faq = [
+  {
+    q: "Pourquoi un plan gratuit limité à 10 factures/mois ?",
+    a: "Le plan gratuit sert à découvrir InvoiceOps et envoyer vos premières factures sans engagement. Au-delà de 10 factures/mois, le plan Pro débloque le dépôt Chorus Pro, le Factur-X, l'e-reporting et tout le moteur de conformité — c'est ce dont vous aurez besoin dès septembre 2026.",
+  },
+  {
+    q: "Que se passe-t-il après les 30 jours d'essai gratuit ?",
+    a: "L'essai démarre sans carte bancaire. Au bout de 30 jours, soit vous renseignez un moyen de paiement pour passer en Pro à 49€/mois, soit votre compte bascule automatiquement sur le plan gratuit (10 factures/mois). Aucun prélèvement surprise.",
+  },
+  {
+    q: "La TVA française est-elle incluse dans les 49€ ?",
+    a: "Non. Le prix affiché est HT. La TVA française (20%) est appliquée à la facturation. Pour un compte professionnel, la TVA est récupérable.",
+  },
+  {
+    q: "Est-ce que le dépôt Chorus Pro est vraiment inclus ?",
+    a: "Oui. InvoiceOps soumet vos factures Factur-X directement à Chorus Pro / PPF via l'API officielle PISTE. Vous pouvez utiliser nos identifiants de plateforme ou configurer les vôtres (chiffrés AES-256). Le statut de dépôt est polled en temps réel.",
+  },
+  {
+    q: "Puis-je annuler à tout moment ?",
+    a: "Oui. Vous pouvez annuler depuis votre tableau de bord, sans pénalité. Vos factures déjà émises restent accessibles et exportables.",
+  },
+  {
+    q: "Est-ce que je peux migrer mes données depuis un autre logiciel ?",
+    a: "Oui. Nous accompagnons gratuitement la migration de vos clients, articles et historique de factures depuis Pennylane, QuickBooks, Tiime, Indy ou un export CSV. Contactez-nous via le formulaire programme pilote.",
+  },
+  {
+    q: "InvoiceOps fonctionne-t-il pour les sous-traitants BTP en autoliquidation ?",
+    a: "C'est notre cœur de cible. Nous gérons l'autoliquidation TVA (article 283-2 nonies du CGI), les factures de situation, la retenue de garantie 5%, et le code EN 16931 dans le XML Factur-X — exactement les cas qui font rejeter les factures sur Chorus Pro.",
+  },
+  {
+    q: "Mes données sont-elles hébergées en France ?",
+    a: "Les données sont hébergées dans l'UE (RGPD-compliant). Les identifiants Chorus Pro per-tenant sont chiffrés AES-256-GCM. Voir notre politique de confidentialité pour le détail.",
+  },
+];
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faq.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+const productJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Product',
+  name: 'InvoiceOps Pro',
+  description:
+    "Facturation électronique conforme Chorus Pro / Factur-X pour les sous-traitants BTP. Génération PDF/A-3 + XML, dépôt direct Chorus Pro, e-reporting DGFiP.",
+  brand: { '@type': 'Brand', name: 'InvoiceOps' },
+  offers: {
+    '@type': 'Offer',
+    price: '49.00',
+    priceCurrency: 'EUR',
+    priceSpecification: {
+      '@type': 'UnitPriceSpecification',
+      price: '49.00',
+      priceCurrency: 'EUR',
+      referenceQuantity: { '@type': 'QuantitativeValue', value: 1, unitCode: 'MON' },
+    },
+    availability: 'https://schema.org/InStock',
+    url: 'https://invoiceops.fr/pricing',
+  },
+};
+
+export default function PricingPage() {
+  return (
+    <>
+      <Script id="ld-pricing-faq" type="application/ld+json" strategy="beforeInteractive">
+        {JSON.stringify(faqJsonLd)}
+      </Script>
+      <Script id="ld-pricing-product" type="application/ld+json" strategy="beforeInteractive">
+        {JSON.stringify(productJsonLd)}
+      </Script>
+
+      <main style={{ backgroundColor: '#08090a', color: '#f7f8f8', minHeight: '100vh', paddingBottom: '6rem' }}>
+        <section style={{ padding: '6rem 0 3rem' }}>
+          <div className="main-container">
+            <div style={{ textAlign: 'center', maxWidth: '720px', margin: '0 auto' }}>
+              <div style={{ fontSize: '0.75rem', fontWeight: 590, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#D4921A', marginBottom: '1rem' }}>
+                Tarifs
+              </div>
+              <h1 style={{
+                fontSize: 'clamp(2rem, 4vw, 3rem)',
+                fontWeight: 590,
+                letterSpacing: '-0.03em',
+                color: '#f7f8f8',
+                marginBottom: '1rem',
+                lineHeight: 1.1,
+              }}>
+                Simple. Prévisible. Prêt pour 2026.
+              </h1>
+              <p style={{ fontSize: '1.0625rem', color: '#8a8f98', lineHeight: 1.6 }}>
+                Commencez gratuitement avec 10 factures par mois. Passez au Pro quand votre volume ou la réforme l'exige —
+                Factur-X, Chorus Pro et e-reporting inclus.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section style={{ padding: '0 0 4rem' }}>
+          <div className="main-container">
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: '1.5rem',
+                maxWidth: '860px',
+                margin: '0 auto',
+              }}
+              className="pricing-grid"
+            >
+              <div style={{
+                backgroundColor: 'rgba(255,255,255,0.02)',
+                border: '1px solid rgba(255,255,255,0.07)',
+                borderRadius: '12px',
+                padding: '2rem',
+                display: 'flex',
+                flexDirection: 'column',
+              }}>
+                <div style={{ marginBottom: '1.75rem' }}>
+                  <div style={{ fontSize: '0.75rem', fontWeight: 590, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#62666d', marginBottom: '1rem' }}>
+                    Gratuit
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px', marginBottom: '0.5rem' }}>
+                    <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '2.5rem', fontWeight: 500, color: '#f7f8f8', letterSpacing: '-0.04em' }}>0 €</span>
+                    <span style={{ fontSize: '0.875rem', color: '#62666d' }}> / mois</span>
+                  </div>
+                  <p style={{ fontSize: '0.875rem', color: '#8a8f98', lineHeight: 1.6, margin: 0 }}>
+                    Pour découvrir la plateforme et envoyer vos premières factures.
+                  </p>
+                </div>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '2rem', flex: 1 }}>
+                  {freeFeatures.map((f) => (
+                    <div key={f} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                      <i className="bi bi-check2" style={{ color: '#10b981', fontSize: '0.9rem', flexShrink: 0 }} />
+                      <span style={{ fontSize: '0.875rem', color: '#d0d6e0' }}>{f}</span>
+                    </div>
+                  ))}
+                </div>
+
+                <Link
+                  href="/auth/register"
+                  style={{
+                    display: 'block',
+                    textAlign: 'center',
+                    padding: '9px 20px',
+                    backgroundColor: 'rgba(255,255,255,0.04)',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    color: '#d0d6e0',
+                    borderRadius: '6px',
+                    fontSize: '0.9rem',
+                    fontWeight: 510,
+                    textDecoration: 'none',
+                  }}
+                >
+                  Commencer gratuitement
+                </Link>
+              </div>
+
+              <div style={{
+                backgroundColor: 'rgba(212,146,26,0.04)',
+                border: '1px solid rgba(212,146,26,0.25)',
+                borderRadius: '12px',
+                padding: '2rem',
+                display: 'flex',
+                flexDirection: 'column',
+                position: 'relative',
+                overflow: 'hidden',
+              }}>
+                <div style={{
+                  position: 'absolute', top: 0, left: 0, right: 0, height: '1px',
+                  background: 'linear-gradient(90deg, transparent, rgba(212,146,26,0.5), transparent)',
+                  pointerEvents: 'none',
+                }} />
+
+                <div style={{ marginBottom: '1.75rem' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' }}>
+                    <div style={{ fontSize: '0.75rem', fontWeight: 590, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#D4921A' }}>
+                      Pro
+                    </div>
+                    <span style={{
+                      fontSize: '0.6rem', fontWeight: 590, letterSpacing: '0.06em', textTransform: 'uppercase',
+                      padding: '3px 8px',
+                      backgroundColor: 'rgba(212,146,26,0.12)',
+                      border: '1px solid rgba(212,146,26,0.25)',
+                      borderRadius: '4px',
+                      color: '#D4921A',
+                    }}>
+                      30 jours offerts
+                    </span>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px', marginBottom: '0.5rem' }}>
+                    <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '2.5rem', fontWeight: 500, color: '#f7f8f8', letterSpacing: '-0.04em' }}>49 €</span>
+                    <span style={{ fontSize: '0.875rem', color: '#62666d' }}> HT / mois</span>
+                  </div>
+                  <p style={{ fontSize: '0.875rem', color: '#8a8f98', lineHeight: 1.6, margin: 0 }}>
+                    Tout le workflow, de l'extraction IA au dépôt Chorus Pro — conforme 2026 dès aujourd'hui.
+                  </p>
+                </div>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '2rem', flex: 1 }}>
+                  {proFeatures.map((f) => (
+                    <div key={f} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                      <i className="bi bi-check2" style={{ color: '#D4921A', fontSize: '0.9rem', flexShrink: 0 }} />
+                      <span style={{ fontSize: '0.875rem', color: '#d0d6e0' }}>{f}</span>
+                    </div>
+                  ))}
+                </div>
+
+                <Link
+                  href="/auth/register"
+                  style={{
+                    display: 'block',
+                    textAlign: 'center',
+                    padding: '9px 20px',
+                    backgroundColor: '#D4921A',
+                    color: '#08090a',
+                    borderRadius: '6px',
+                    fontSize: '0.9rem',
+                    fontWeight: 600,
+                    textDecoration: 'none',
+                  }}
+                >
+                  Démarrer l'essai gratuit
+                </Link>
+              </div>
+            </div>
+
+            <p style={{ textAlign: 'center', fontSize: '0.8125rem', color: '#62666d', marginTop: '1.75rem' }}>
+              Pas de carte bancaire requise pour l'essai · Annulation à tout moment · TVA française applicable
+            </p>
+          </div>
+        </section>
+
+        <section style={{ padding: '4rem 0', borderTop: '1px solid rgba(255,255,255,0.05)' }}>
+          <div className="main-container" style={{ maxWidth: '860px' }}>
+            <div style={{ textAlign: 'center', marginBottom: '2.5rem' }}>
+              <div style={{ fontSize: '0.75rem', fontWeight: 590, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#D4921A', marginBottom: '0.75rem' }}>
+                Comparaison
+              </div>
+              <h2 style={{ fontSize: 'clamp(1.5rem, 2.5vw, 2rem)', fontWeight: 590, letterSpacing: '-0.02em', color: '#f7f8f8', margin: 0 }}>
+                Ce qui change quand vous passez au Pro
+              </h2>
+            </div>
+
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+                <thead>
+                  <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+                    <th style={{ textAlign: 'left', padding: '0.75rem 1rem', color: '#8a8f98', fontWeight: 510 }}>Fonctionnalité</th>
+                    <th style={{ textAlign: 'center', padding: '0.75rem 1rem', color: '#8a8f98', fontWeight: 510, width: '120px' }}>Gratuit</th>
+                    <th style={{ textAlign: 'center', padding: '0.75rem 1rem', color: '#D4921A', fontWeight: 510, width: '120px' }}>Pro</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {comparison.map((row) => (
+                    <tr key={row.feature} style={{ borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+                      <td style={{ padding: '0.875rem 1rem', color: '#d0d6e0' }}>{row.feature}</td>
+                      <td style={{ padding: '0.875rem 1rem', textAlign: 'center', color: row.free === false ? '#62666d' : '#d0d6e0' }}>
+                        {row.free === true ? <i className="bi bi-check2" style={{ color: '#10b981' }} /> : row.free === false ? <i className="bi bi-dash" /> : row.free}
+                      </td>
+                      <td style={{ padding: '0.875rem 1rem', textAlign: 'center', color: row.pro === false ? '#62666d' : '#d0d6e0' }}>
+                        {row.pro === true ? <i className="bi bi-check2" style={{ color: '#D4921A' }} /> : row.pro === false ? <i className="bi bi-dash" /> : row.pro}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section style={{ padding: '4rem 0', borderTop: '1px solid rgba(255,255,255,0.05)' }}>
+          <div className="main-container" style={{ maxWidth: '760px' }}>
+            <div style={{ textAlign: 'center', marginBottom: '2.5rem' }}>
+              <div style={{ fontSize: '0.75rem', fontWeight: 590, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#D4921A', marginBottom: '0.75rem' }}>
+                Questions fréquentes
+              </div>
+              <h2 style={{ fontSize: 'clamp(1.5rem, 2.5vw, 2rem)', fontWeight: 590, letterSpacing: '-0.02em', color: '#f7f8f8', margin: 0 }}>
+                Réponses aux questions courantes
+              </h2>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1px', backgroundColor: 'rgba(255,255,255,0.05)' }}>
+              {faq.map((item) => (
+                <details key={item.q} style={{ backgroundColor: '#08090a', padding: '1.25rem 1.5rem' }}>
+                  <summary style={{ cursor: 'pointer', listStyle: 'none', color: '#f7f8f8', fontWeight: 510, fontSize: '0.95rem' }}>
+                    {item.q}
+                  </summary>
+                  <p style={{ marginTop: '0.75rem', color: '#8a8f98', fontSize: '0.9rem', lineHeight: 1.7, marginBottom: 0 }}>
+                    {item.a}
+                  </p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section style={{ padding: '4rem 0 0' }}>
+          <div className="main-container" style={{ maxWidth: '600px', textAlign: 'center' }}>
+            <h2 style={{ fontSize: 'clamp(1.5rem, 2.5vw, 2rem)', fontWeight: 590, letterSpacing: '-0.02em', color: '#f7f8f8', marginBottom: '1rem' }}>
+              Prêt à déposer sans rejet sur Chorus Pro ?
+            </h2>
+            <p style={{ fontSize: '1rem', color: '#8a8f98', lineHeight: 1.6, marginBottom: '2rem' }}>
+              Créez votre compte en 2 minutes. Plan gratuit jusqu'à 10 factures/mois — sans carte bancaire.
+            </p>
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+              <Link
+                href="/auth/register"
+                style={{
+                  display: 'inline-block',
+                  padding: '12px 24px',
+                  backgroundColor: '#D4921A',
+                  color: '#08090a',
+                  borderRadius: '6px',
+                  fontSize: '0.95rem',
+                  fontWeight: 600,
+                  textDecoration: 'none',
+                }}
+              >
+                Créer un compte gratuit →
+              </Link>
+              <Link
+                href="/comment-ca-marche"
+                style={{
+                  display: 'inline-block',
+                  padding: '12px 24px',
+                  backgroundColor: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  color: '#d0d6e0',
+                  borderRadius: '6px',
+                  fontSize: '0.95rem',
+                  fontWeight: 510,
+                  textDecoration: 'none',
+                }}
+              >
+                Comment ça marche
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -33,6 +33,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE_URL}/pricing`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
       url: `${SITE_URL}/blog`,
       lastModified,
       changeFrequency: "weekly",

--- a/src/lib/blog/posts.ts
+++ b/src/lib/blog/posts.ts
@@ -16,6 +16,16 @@ export interface BlogPost {
  */
 export const posts: BlogPost[] = [
   {
+    slug: 'retenue-de-garantie-btp-facturx',
+    title: 'Retenue de garantie 5% en BTP : comment l\'encoder dans Factur-X sans rejet Chorus Pro',
+    description:
+      "La retenue de garantie 5% sur les marchés BTP doit apparaître sur la facture ET dans le XML Factur-X. Guide pratique : règles légales, exemple chiffré, codes EN 16931, libération de la RG et erreurs Chorus Pro à éviter.",
+    publishedAt: '2026-05-04',
+    readingMinutes: 8,
+    tags: ['BTP', 'retenue de garantie', 'Factur-X', 'Chorus Pro', 'EN 16931'],
+    author: { name: 'InvoiceOps', url: 'https://invoiceops.fr' },
+  },
+  {
     slug: 'tva-autoliquidation-btp',
     title: 'TVA autoliquidation BTP : guide complet 2026 (avec exemple Factur-X)',
     description:


### PR DESCRIPTION
## Summary
Production release — promotes #164 (which contains #163).

- New /pricing standalone page with FAQ + JSON-LD
- New blog article on retenue de garantie 5% in BTP
- Footer nav and sitemap updated

## Test plan
- [ ] Prod build green
- [ ] vercel --prod after merge
- [ ] Smoke check: invoiceops.fr/pricing, invoiceops.fr/blog/retenue-de-garantie-btp-facturx, sitemap.xml