### PR TITLE
Merge dev → staging: gitignore tool caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,11 @@ next-env.d.ts
 
 # Local credentials notes (never commit)
 *.local.md
+
+# Tool caches (Claude Code, Playwright MCP)
+.claude/
+.playwright-mcp/
+
+# next-pwa / Workbox source maps (regenerated on every build)
+public/sw.js.map
+public/workbox-*.js.map


### PR DESCRIPTION
Promotes #169 — .gitignore additions only, no prod impact.