### PR TITLE
fix(seo): satisfy Merchant Listings (image, shipping, returns)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -132,10 +132,35 @@ const organizationSchema = {
   },
 };
 
+const digitalShippingDetails = {
+  "@type": "OfferShippingDetails",
+  shippingRate: {
+    "@type": "MonetaryAmount",
+    value: "0",
+    currency: "EUR",
+  },
+  shippingDestination: {
+    "@type": "DefinedRegion",
+    addressCountry: "FR",
+  },
+  deliveryTime: {
+    "@type": "ShippingDeliveryTime",
+    handlingTime: { "@type": "QuantitativeValue", minValue: 0, maxValue: 0, unitCode: "DAY" },
+    transitTime: { "@type": "QuantitativeValue", minValue: 0, maxValue: 0, unitCode: "DAY" },
+  },
+};
+
+const noReturnsPolicy = {
+  "@type": "MerchantReturnPolicy",
+  applicableCountry: "FR",
+  returnPolicyCategory: "https://schema.org/MerchantReturnNotPermitted",
+};
+
 const softwareSchema = {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   name: SITE_NAME,
+  image: `${SITE_URL}/icons/icon-512x512.png`,
   applicationCategory: "BusinessApplication",
   operatingSystem: "Web",
   inLanguage: "fr-FR",
@@ -147,14 +172,23 @@ const softwareSchema = {
       name: "Plan Gratuit",
       price: "0",
       priceCurrency: "EUR",
+      availability: "https://schema.org/InStock",
+      url: `${SITE_URL}/pricing`,
       description: "Jusqu'à 10 factures par mois, clients illimités, lien de paiement Stripe.",
+      shippingDetails: digitalShippingDetails,
+      hasMerchantReturnPolicy: noReturnsPolicy,
     },
     {
       "@type": "Offer",
       name: "Plan Pro",
+      price: "49.00",
       priceCurrency: "EUR",
+      availability: "https://schema.org/InStock",
+      url: `${SITE_URL}/pricing`,
       description:
         "Factures illimitées, Factur-X, dépôt Chorus Pro, e-reporting B2C, extraction IA, validation SIRET INSEE.",
+      shippingDetails: digitalShippingDetails,
+      hasMerchantReturnPolicy: noReturnsPolicy,
     },
   ],
   publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -105,6 +105,7 @@ const productJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
   name: 'InvoiceOps Pro',
+  image: 'https://invoiceops.fr/icons/icon-512x512.png',
   description:
     "Facturation électronique conforme Chorus Pro / Factur-X pour les sous-traitants BTP. Génération PDF/A-3 + XML, dépôt direct Chorus Pro, e-reporting DGFiP.",
   applicationCategory: 'BusinessApplication',
@@ -124,6 +125,28 @@ const productJsonLd = {
     },
     availability: 'https://schema.org/InStock',
     url: 'https://invoiceops.fr/pricing',
+    shippingDetails: {
+      '@type': 'OfferShippingDetails',
+      shippingRate: {
+        '@type': 'MonetaryAmount',
+        value: '0',
+        currency: 'EUR',
+      },
+      shippingDestination: {
+        '@type': 'DefinedRegion',
+        addressCountry: 'FR',
+      },
+      deliveryTime: {
+        '@type': 'ShippingDeliveryTime',
+        handlingTime: { '@type': 'QuantitativeValue', minValue: 0, maxValue: 0, unitCode: 'DAY' },
+        transitTime: { '@type': 'QuantitativeValue', minValue: 0, maxValue: 0, unitCode: 'DAY' },
+      },
+    },
+    hasMerchantReturnPolicy: {
+      '@type': 'MerchantReturnPolicy',
+      applicableCountry: 'FR',
+      returnPolicyCategory: 'https://schema.org/MerchantReturnNotPermitted',
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- Google Search Console flagged 3 issues on the Merchant Listings rich result: critical missing \`image\`, plus non-critical \`shippingDetails\` and \`hasMerchantReturnPolicy\` on every \`Offer\`.
- PR #166 swapped \`Product\` → \`SoftwareApplication\`, but Google's Merchant Listings parser triggers on the presence of \`offers\` regardless of the parent type.
- Adds \`image\` (logo URL), digital-goods \`OfferShippingDetails\` (zero rate, FR, instant), and \`MerchantReturnPolicy\` (\`MerchantReturnNotPermitted\`, FR) to both \`src/app/layout.tsx\` (\`softwareSchema\`) and \`src/app/pricing/page.tsx\` (\`productJsonLd\`).
- Bonus: the "Plan Pro" Offer in \`layout.tsx\` was previously emitting with no \`price\` field — now \`price: "49.00"\` + \`availability: InStock\`.

## Test plan
- [ ] After staging deploy, paste \`https://staging-invoiceops.fr/\` and \`https://staging-invoiceops.fr/pricing\` into the [Rich Results Test](https://search.google.com/test/rich-results) and confirm zero Merchant Listings errors.
- [ ] After prod deploy, repeat with the prod URLs.
- [ ] In GSC, click "Validate Fix" on each of the 3 issues in the Merchant Listings report.
- [ ] Re-submit \`https://invoiceops.fr/sitemap.xml\` to trigger re-crawl.